### PR TITLE
Fix make distclean without keyvalue

### DIFF
--- a/datastore/Makefile.in
+++ b/datastore/Makefile.in
@@ -121,7 +121,7 @@ clean:
 
 distclean: clean
 	rm -f Makefile *~ .depend
-	for i in $(SUBDIRS); \
+	for i in $(sort $(SUBDIRS) keyvalue); \
 	do (cd $$i; $(MAKE) $(MFLAGS) $@); done
 
 tags:


### PR DESCRIPTION
When --with-keyvalue is not selected in configure, keyvalue is not added
to SUBDIRS variable under datastore Makefile and when distclean runs
datastore/keyvalue/Makefile is left behind. Add keyvalue to the SUBDIRS
loop using sort function to prevent it to be duplicated