### PR TITLE
Do not remove clixonrc on install-include

### DIFF
--- a/etc/Makefile.in
+++ b/etc/Makefile.in
@@ -52,10 +52,10 @@ install:	 clixonrc
 	install -m 755 clixonrc $(DESTDIR)$(sysconfdir)
 
 install-include:	
-	rm -f $(DESTDIR)$(sysconfdir)/clixonrc
+
 
 uninstall:
-
+	rm -f $(DESTDIR)$(sysconfdir)/clixonrc
 
 depend:
 


### PR DESCRIPTION
Remove clixonrc on the right target, uninstall, instead of doing that on install-include