### PR TITLE
Use default config file when none is provided

### DIFF
--- a/configure
+++ b/configure
@@ -709,6 +709,7 @@ with_cligen
 with_restconf
 with_keyvalue
 with_qdbm
+with_configfile
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1347,6 +1348,7 @@ Optional Packages:
   --without-restconf      disable support for restconf
   --with-keyvalue         enable support for key-value xmldb datastore
   --with-qdbm=dir         Use QDBM here, if keyvalue
+  --with-configfile       set default path to config file
 
 Some influential environment variables:
   CC          C compiler command
@@ -4045,6 +4047,16 @@ fi
 
 fi
 
+# Set default config file location
+
+# Check whether --with-configfile was given.
+if test "${with_configfile+set}" = set; then :
+  withval=$with_configfile; DEFAULT_CONFIG="$withval"
+else
+  DEFAULT_CONFIG="/etc/clixon.xml"
+fi
+
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for crypt in -lcrypt" >&5
 $as_echo_n "checking for crypt in -lcrypt... " >&6; }
 if ${ac_cv_lib_crypt_crypt+:} false; then :
@@ -4287,6 +4299,13 @@ done
 
 cat >>confdefs.h <<_ACEOF
 #define CLIXON_DATADIR "${prefix}/share/clixon"
+_ACEOF
+
+
+# Default location for config file
+
+cat >>confdefs.h <<_ACEOF
+#define CLIXON_DEFAULT_CONFIG "${DEFAULT_CONFIG}"
 _ACEOF
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -161,6 +161,12 @@ if test "x${with_keyvalue}" == xyes; then
    AC_CONFIG_FILES(datastore/keyvalue/Makefile)
 fi
 
+# Set default config file location
+AC_ARG_WITH([configfile],
+	    [AS_HELP_STRING([--with-configfile],[set default path to config file])],
+	    [DEFAULT_CONFIG="$withval"],
+	    [DEFAULT_CONFIG="/etc/clixon.xml"])
+
 AC_CHECK_LIB(crypt, crypt)
 AC_CHECK_HEADERS(crypt.h)
 
@@ -181,6 +187,9 @@ AC_CHECK_FUNCS(inet_aton sigaction sigvec strlcpy strsep strndup alphasort versi
 # This is to find clixon system files in the source code.
 # same as clixon_DATADIR defined in clixon.mk.cpp for Makefiles
 AC_DEFINE_UNQUOTED(CLIXON_DATADIR, "${prefix}/share/clixon", [Clixon data dir for system yang files etc])
+
+# Default location for config file
+AC_DEFINE_UNQUOTED(CLIXON_DEFAULT_CONFIG,"${DEFAULT_CONFIG}",[Location for apps to find default config file])
 
 AH_BOTTOM([#include <clixon_custom.h>])
 

--- a/include/clixon_config.h.in
+++ b/include/clixon_config.h.in
@@ -3,6 +3,9 @@
 /* Clixon data dir for system yang files etc */
 #undef CLIXON_DATADIR
 
+/* Location for apps to find default config file */
+#undef CLIXON_DEFAULT_CONFIG
+
 /* Clixon major release */
 #undef CLIXON_VERSION_MAJOR
 

--- a/lib/src/clixon_options.c
+++ b/lib/src/clixon_options.c
@@ -202,8 +202,7 @@ clicon_options_main(clicon_handle h)
      * Set configure file if not set by command-line above
      */
     if (!hash_lookup(copt, "CLICON_CONFIGFILE")){ 
-	clicon_err(OE_CFG, 0, "CLICON_CONFIGFILE (-f) not set");
-	goto done;
+	clicon_option_str_set(h, "CLICON_CONFIGFILE", CLIXON_DEFAULT_CONFIG);
     }
     configfile = hash_value(copt, "CLICON_CONFIGFILE", NULL);
     clicon_debug(1, "CLICON_CONFIGFILE=%s", configfile);


### PR DESCRIPTION
Add config option to set a default config file path. If
none given, the default config file path is /etc/clixon.xml.

This will allow running apps without necessarily having
to use -f argument to specify config file.
