### PR TITLE
Augment help text for --with-configfile

### DIFF
--- a/configure
+++ b/configure
@@ -1348,7 +1348,7 @@ Optional Packages:
   --without-restconf      disable support for restconf
   --with-keyvalue         enable support for key-value xmldb datastore
   --with-qdbm=dir         Use QDBM here, if keyvalue
-  --with-configfile       set default path to config file
+  --with-configfile=FILE  set default path to config file
 
 Some influential environment variables:
   CC          C compiler command

--- a/configure.ac
+++ b/configure.ac
@@ -163,7 +163,7 @@ fi
 
 # Set default config file location
 AC_ARG_WITH([configfile],
-	    [AS_HELP_STRING([--with-configfile],[set default path to config file])],
+	    [AS_HELP_STRING([--with-configfile=FILE],[set default path to config file])],
 	    [DEFAULT_CONFIG="$withval"],
 	    [DEFAULT_CONFIG="/etc/clixon.xml"])
 


### PR DESCRIPTION
Include '=FILE' at the end to make correct usage clearer