### PR TITLE
Make default config to respect sysconfdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ etc/clixonrc
 example/*.conf
 
 include/clixon_config.h
+include/clixon_config.h.in
 
 lib/src/build.c
 lib/clixon/clixon.h

--- a/configure
+++ b/configure
@@ -2161,7 +2161,7 @@ else
 	CLIGEN_PREFIX="$prefix"
 fi
 
-ac_config_headers="$ac_config_headers include/clixon_config.h lib/clixon/clixon.h"
+ac_config_headers="$ac_config_headers include/clixon_config.h.in lib/clixon/clixon.h"
 
 
 
@@ -4053,7 +4053,7 @@ fi
 if test "${with_configfile+set}" = set; then :
   withval=$with_configfile; DEFAULT_CONFIG="$withval"
 else
-  DEFAULT_CONFIG="/etc/clixon.xml"
+  DEFAULT_CONFIG="%%sysconfdir%%/clixon.xml"
 fi
 
 
@@ -5003,7 +5003,7 @@ cat >>$CONFIG_STATUS <<\_ACEOF || ac_write_fail=1
 for ac_config_target in $ac_config_targets
 do
   case $ac_config_target in
-    "include/clixon_config.h") CONFIG_HEADERS="$CONFIG_HEADERS include/clixon_config.h" ;;
+    "include/clixon_config.h.in") CONFIG_HEADERS="$CONFIG_HEADERS include/clixon_config.h.in" ;;
     "lib/clixon/clixon.h") CONFIG_HEADERS="$CONFIG_HEADERS lib/clixon/clixon.h" ;;
     "datastore/keyvalue/Makefile") CONFIG_FILES="$CONFIG_FILES datastore/keyvalue/Makefile" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;

--- a/configure.ac
+++ b/configure.ac
@@ -53,7 +53,7 @@ else
 	CLIGEN_PREFIX="$prefix"
 fi
 
-AC_CONFIG_HEADERS([include/clixon_config.h lib/clixon/clixon.h])
+AC_CONFIG_HEADERS([include/clixon_config.h.in lib/clixon/clixon.h])
 
 AC_DEFINE_UNQUOTED(CLIXON_VERSION_STRING, $CLIXON_VERSION, [Clixon version string])
 AC_DEFINE_UNQUOTED(CLIXON_VERSION_MAJOR, $CLIXON_VERSION_MAJOR, [Clixon major release])
@@ -165,7 +165,7 @@ fi
 AC_ARG_WITH([configfile],
 	    [AS_HELP_STRING([--with-configfile=FILE],[set default path to config file])],
 	    [DEFAULT_CONFIG="$withval"],
-	    [DEFAULT_CONFIG="/etc/clixon.xml"])
+	    [DEFAULT_CONFIG="%%sysconfdir%%/clixon.xml"])
 
 AC_CHECK_LIB(crypt, crypt)
 AC_CHECK_HEADERS(crypt.h)

--- a/include/Makefile.in
+++ b/include/Makefile.in
@@ -41,13 +41,17 @@ localstatedir	= @localstatedir@
 sysconfdir	= @sysconfdir@
 INSTALL		= @INSTALL@
 
-all:	
+all:	clixon_config.h
 	@echo " "
 
 clean:
 
+clixon_config.h:
+	@sed -e "s,%%sysconfdir%%,${sysconfdir},g" \
+		clixon_config.h.in > clixon_config.h
+
 distclean: clean
-	rm -f clixon_config.h Makefile *~ .depend
+	rm -f clixon_config.h clixon_config.h.in Makefile *~ .depend
 
 install:	
 

--- a/include/clixon_config.h.in.in
+++ b/include/clixon_config.h.in.in
@@ -1,4 +1,4 @@
-/* include/clixon_config.h.in.  Generated from configure.ac by autoheader.  */
+/* include/clixon_config.h.in.in.  Generated from configure.ac by autoheader.  */
 
 /* Clixon data dir for system yang files etc */
 #undef CLIXON_DATADIR


### PR DESCRIPTION
Instead of hardcode default config to /etc/clixon.xml, make it to
respect sysconfdir variable. Since autoconf doesn't expand variables on
header substitution it would end up being defined on clixon_config.h as
"${prefix}/etc/clixon.xml" what makes no sense for the header file.

To workaround this no-expand-variable issue I renamed clixon_config.h.in
to clixon_config.h.in.in and defined default value of
CLIXON_DEFAULT_CONFIG as %%sysconfdir%%/clixon.xml. Then
include/Makefile will be responsible to run the 2nd pass substitution
and using sed replace %%sysconfdir%% by expanded value of ${sysconfdir}.