### PR TITLE
Make default config to respect sysconfdir

### DIFF
--- a/configure
+++ b/configure
@@ -4053,7 +4053,7 @@ fi
 if test "${with_configfile+set}" = set; then :
   withval=$with_configfile; DEFAULT_CONFIG="$withval"
 else
-  DEFAULT_CONFIG="/etc/clixon.xml"
+  DEFAULT_CONFIG="$(eval echo ${sysconfdir}/clixon.xml)"
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ fi
 AC_ARG_WITH([configfile],
 	    [AS_HELP_STRING([--with-configfile=FILE],[set default path to config file])],
 	    [DEFAULT_CONFIG="$withval"],
-	    [DEFAULT_CONFIG="/etc/clixon.xml"])
+	    [DEFAULT_CONFIG="$(eval echo ${sysconfdir}/clixon.xml)"])
 
 AC_CHECK_LIB(crypt, crypt)
 AC_CHECK_HEADERS(crypt.h)


### PR DESCRIPTION
Instead of hardcode default config to /etc/clixon.xml, make it to
respect sysconfdir variable. Since autoconf doesn't expand variables on
header substitution it would end up being defined on clixon_config.h as
"${prefix}/etc/clixon.xml" what makes no sense for the header file.

Use eval to expand ${sysconfdir} and make .h file to be defined with
final directory name.