### PR TITLE
Improve permissions and strip binaries

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -69,8 +69,8 @@ clixon.mk:  clixon.mk.cpp
 	$(CPP) -P -traditional-cpp -x assembler-with-cpp -Dprefix=$(prefix) -Dlocalstatedir=$(localstatedir) -Dsysconfdir=$(sysconfdir) -Ddatadir=$(datadir) -Dlibdir=$(libdir) $< > $@
 
 install:  clixon.mk
-	install -d -m 755 $(DESTDIR)$(datadir)/clixon
-	install -m 755 clixon.mk $(DESTDIR)$(datadir)/clixon
+	install -d -m 0755 $(DESTDIR)$(datadir)/clixon
+	install -m 0644 clixon.mk $(DESTDIR)$(datadir)/clixon
 	for i in $(SUBDIRS) doc; \
 	do (cd $$i; $(MAKE) $(MFLAGS) $@)||exit 1; done; \
 	echo "Install for compilation by: make install-include"

--- a/apps/backend/Makefile.in
+++ b/apps/backend/Makefile.in
@@ -98,15 +98,15 @@ distclean: clean
 # Also create a libexec/ directory for writeable/temporary files.
 # Put config file in etc/
 install:	install-lib	$(APPL)
-	install -d $(DESTDIR)$(sbindir)
-	install $(APPL) $(DESTDIR)$(sbindir)
+	install -d -m 0755 $(DESTDIR)$(sbindir)
+	install -m 0755 -s $(APPL) $(DESTDIR)$(sbindir)
 
 install-lib:	$(MYLIB)
-	install -d $(DESTDIR)$(libdir)
-	install $(MYLIB) $(DESTDIR)$(libdir)
+	install -d -m 0755 $(DESTDIR)$(libdir)
+	install -m 0644 -s $(MYLIB) $(DESTDIR)$(libdir)
 	ln -sf $(MYLIB) $(DESTDIR)$(libdir)/$(MYLIBSO)	   # -l:libclixon_config.so.2
 	ln -sf $(MYLIBSO) $(DESTDIR)$(libdir)/$(MYLIBLINK) # -l:libclixon_config.so
-	install -d $(DESTDIR)$(libdir)/clixon/plugins/backend
+	install -d -m 0755 $(DESTDIR)$(libdir)/clixon/plugins/backend
 
 uninstall:
 	rm -f $(DESTDIR)$(sbindir)/$(APPL)
@@ -114,8 +114,8 @@ uninstall:
 	rm -f $(DESTDIR)$(includedir)/clixon/*
 
 install-include: clixon_backend.h clixon_backend_handle.h clixon_backend_transaction.h
-	install -d $(DESTDIR)$(includedir)/clixon
-	install -m 644 $^ $(DESTDIR)$(includedir)/clixon
+	install -d -m 0755 $(DESTDIR)$(includedir)/clixon
+	install -m 0644 $^ $(DESTDIR)$(includedir)/clixon
 
 .SUFFIXES:
 .SUFFIXES: .c .o

--- a/apps/cli/Makefile.in
+++ b/apps/cli/Makefile.in
@@ -102,19 +102,19 @@ distclean: clean
 # Also create a libexec/ directory for writeable/temporary files.
 # Put config file in etc/
 install: install-lib $(APPL) 
-	install -d $(DESTDIR)$(bindir) 
-	install $(APPL) $(DESTDIR)$(bindir) 
+	install -d -m 0755 $(DESTDIR)$(bindir)
+	install -m 0644 -s $(APPL) $(DESTDIR)$(bindir)
 
 install-lib: $(MYLIB)
-	install -d $(DESTDIR)$(libdir) 
-	install $(MYLIB) $(DESTDIR)$(libdir) 
+	install -d -m 0755 $(DESTDIR)$(libdir)
+	install -m 0644 -s $(MYLIB) $(DESTDIR)$(libdir)
 	ln -sf $(MYLIB) $(DESTDIR)$(libdir)/$(MYLIBSO)     # -l:libclixon_cli.so.2
 	ln -sf $(MYLIBSO) $(DESTDIR)$(libdir)/$(MYLIBLINK) # -l:libclixon_cli.so
-	install -d $(DESTDIR)$(libdir)/clixon/plugins/cli
+	install -d -m 0755 $(DESTDIR)$(libdir)/clixon/plugins/cli
 
 install-include:	clixon_cli.h clixon_cli_api.h
-	install -d $(DESTDIR)$(includedir)/clixon
-	install -m 644 $^ $(DESTDIR)$(includedir)/clixon
+	install -d -m 0755 $(DESTDIR)$(includedir)/clixon
+	install -m 0644 $^ $(DESTDIR)$(includedir)/clixon
 
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/$(APPL)

--- a/apps/netconf/Makefile.in
+++ b/apps/netconf/Makefile.in
@@ -100,18 +100,18 @@ distclean: clean
 # Also create a libexec/ directory for writeable/temporary files.
 # Put config file in etc/
 install:	install-lib $(APPL)
-	install -d $(DESTDIR)$(bindir)
-	install $(APPL) $(DESTDIR)$(bindir)
+	install -d -m 0755 $(DESTDIR)$(bindir)
+	install -m 0755 -s $(APPL) $(DESTDIR)$(bindir)
 
 install-lib: $(MYLIB)
-	install -d $(DESTDIR)$(libdir) 
-	install $(MYLIB) $(DESTDIR)$(libdir) 
+	install -d -m 0755 $(DESTDIR)$(libdir)
+	install -m 0644 -s $(MYLIB) $(DESTDIR)$(libdir)
 	ln -sf $(MYLIB) $(DESTDIR)$(libdir)/$(MYLIBSO)     # -l:libclixon_netconf.so.2
 	ln -sf $(MYLIBSO) $(DESTDIR)$(libdir)/$(MYLIBLINK) # -l:libclixon_netconf.so
 
 install-include:	clixon_netconf.h
-	install -d $(DESTDIR)$(includedir)/clixon
-	install -m 644 $^ $(DESTDIR)$(includedir)/clixon
+	install -d -m 0755 $(DESTDIR)$(includedir)/clixon
+	install -m 0644 $^ $(DESTDIR)$(includedir)/clixon
 
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/$(APPL)

--- a/apps/restconf/Makefile.in
+++ b/apps/restconf/Makefile.in
@@ -97,8 +97,8 @@ distclean: clean
 # Also create a libexec/ directory for writeable/temporary files.
 # Put config file in etc/
 install:	install-lib $(APPL)
-	install -d $(DESTDIR)$(wwwdir)
-	install $(APPL) $(DESTDIR)$(wwwdir)
+	install -d -m 0755 $(DESTDIR)$(wwwdir)
+	install -m 0755 -s $(APPL) $(DESTDIR)$(wwwdir)
 
 install-lib: $(MYLIB)
 	install -d $(DESTDIR)$(libdir) 

--- a/datastore/Makefile.in
+++ b/datastore/Makefile.in
@@ -101,8 +101,8 @@ install-include:
 	do (cd $$i ; $(MAKE) $(MFLAGS) $@)||exit 1; done; 
 
 install: $(APPL)
-	install -d $(DESTDIR)$(bindir)
-	install $(APPL) $(DESTDIR)$(bindir)
+	install -d -m 0755 $(DESTDIR)$(bindir)
+	install -m 0755 -s $(APPL) $(DESTDIR)$(bindir)
 	for i in $(SUBDIRS); \
 	do (cd $$i && $(MAKE) $(MFLAGS) $@)||exit 1; done
 

--- a/datastore/keyvalue/Makefile.in
+++ b/datastore/keyvalue/Makefile.in
@@ -80,8 +80,8 @@ distclean: clean
 	$(CC) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) -c $<
 
 install: $(PLUGIN)
-	install -d $(DESTDIR)$(libdir)/xmldb
-	install $(PLUGIN) $(DESTDIR)$(libdir)/xmldb
+	install -d -m 0755 $(DESTDIR)$(libdir)/xmldb
+	install -m 0644 -s $(PLUGIN) $(DESTDIR)$(libdir)/xmldb
 
 install-include:
 

--- a/datastore/text/Makefile.in
+++ b/datastore/text/Makefile.in
@@ -84,8 +84,8 @@ distclean: clean
 	$(CC) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) -c $<
 
 install: $(PLUGIN)
-	install -d $(DESTDIR)$(libdir)/xmldb
-	install $(PLUGIN) $(DESTDIR)$(libdir)/xmldb
+	install -d -m 0755 $(DESTDIR)$(libdir)/xmldb
+	install -m 0644 -s $(PLUGIN) $(DESTDIR)$(libdir)/xmldb
 
 install-include:
 

--- a/etc/Makefile.in
+++ b/etc/Makefile.in
@@ -48,8 +48,8 @@ distclean: clean
 	rm -f Makefile *~ .depend clixonrc
 
 install:	 clixonrc
-	install -m 755 -d $(DESTDIR)$(sysconfdir) 
-	install -m 755 clixonrc $(DESTDIR)$(sysconfdir)
+	install -m 0755 -d $(DESTDIR)$(sysconfdir)
+	install -m 0644 clixonrc $(DESTDIR)$(sysconfdir)
 
 install-include:	
 

--- a/example/Makefile.in
+++ b/example/Makefile.in
@@ -111,21 +111,21 @@ distclean: clean
 	(cd docker && $(MAKE) $(MFLAGS) $@)
 
 install: $(YANGSPECS) $(CLISPECS) $(BE_PLUGIN) $(BE2_PLUGIN) $(CLI_PLUGIN) $(NETCONF_PLUGIN) $(RESTCONF_PLUGIN) $(APPNAME).xml
-	install -d $(DESTDIR)$(clixon_SYSCONFDIR)
-	install $(APPNAME).xml $(DESTDIR)$(clixon_SYSCONFDIR)
-	install -d $(DESTDIR)$(clixon_DBSPECDIR)/yang
-	install $(YANGSPECS) $(DESTDIR)$(clixon_DBSPECDIR)/yang
-	install -d $(DESTDIR)$(clixon_LIBDIR)/cli
-	install $(CLI_PLUGIN) $(DESTDIR)$(clixon_LIBDIR)/cli; 
-	install -d $(DESTDIR)$(clixon_LIBDIR)/backend
-	install $(BE_PLUGIN) $(BE2_PLUGIN) $(DESTDIR)$(clixon_LIBDIR)/backend; 
-	install -d $(DESTDIR)$(clixon_LIBDIR)/netconf
-	install $(NETCONF_PLUGIN) $(DESTDIR)$(clixon_LIBDIR)/netconf;
-	install -d $(DESTDIR)$(clixon_LIBDIR)/restconf
-	install $(RESTCONF_PLUGIN) $(DESTDIR)$(clixon_LIBDIR)/restconf; 
-	install -d $(DESTDIR)$(clixon_LIBDIR)/clispec
-	install $(CLISPECS) $(DESTDIR)$(clixon_LIBDIR)/clispec; 
-	install -d $(DESTDIR)$(clixon_LOCALSTATEDIR)
+	install -d -m 0755 $(DESTDIR)$(clixon_SYSCONFDIR)
+	install -m 0644 $(APPNAME).xml $(DESTDIR)$(clixon_SYSCONFDIR)
+	install -d -m 0755 $(DESTDIR)$(clixon_DBSPECDIR)/yang
+	install -m 0644 $(YANGSPECS) $(DESTDIR)$(clixon_DBSPECDIR)/yang
+	install -d -m 0755 $(DESTDIR)$(clixon_LIBDIR)/cli
+	install -m 0644 -s $(CLI_PLUGIN) $(DESTDIR)$(clixon_LIBDIR)/cli
+	install -d -m 0755 $(DESTDIR)$(clixon_LIBDIR)/backend
+	install -m 0644 -s $(BE_PLUGIN) $(DESTDIR)$(clixon_LIBDIR)/backend
+	install -d -m 0755 $(DESTDIR)$(clixon_LIBDIR)/netconf
+	install -m 0644 -s $(NETCONF_PLUGIN) $(DESTDIR)$(clixon_LIBDIR)/netconf
+	install -d -m 0755 $(DESTDIR)$(clixon_LIBDIR)/restconf
+	install -m 0644 $(RESTCONF_PLUGIN) $(DESTDIR)$(clixon_LIBDIR)/restconf
+	install -d -m 0755 $(DESTDIR)$(clixon_LIBDIR)/clispec
+	install -m 0644 $(CLISPECS) $(DESTDIR)$(clixon_LIBDIR)/clispec
+	install -d -m 0755 $(DESTDIR)$(clixon_LOCALSTATEDIR)
 	(cd docker && $(MAKE) $(MFLAGS) $@)
 
 uninstall: 

--- a/lib/clixon/Makefile.in
+++ b/lib/clixon/Makefile.in
@@ -44,8 +44,8 @@ depend:
 install:
 
 install-include:	
-	install -m 755 -d $(DESTDIR)$(includedir)/clixon 
-	install -m 644 *.h $(DESTDIR)$(includedir)/clixon 
+	install -m 0755 -d $(DESTDIR)$(includedir)/clixon
+	install -m 0644 *.h $(DESTDIR)$(includedir)/clixon
 
 uninstall:
 	rm -rf $(DESTDIR)$(includedir)/clixon

--- a/lib/src/Makefile.in
+++ b/lib/src/Makefile.in
@@ -181,8 +181,8 @@ install: install-lib
 install-include:
 
 install-lib: $(MYLIB)
-	install -m 755 -d $(DESTDIR)$(libdir) 
-	install -m 755 $(MYLIB) $(DESTDIR)$(libdir) 
+	install -m 0755 -d $(DESTDIR)$(libdir)
+	install -m 0644 -s $(MYLIB) $(DESTDIR)$(libdir)
 	ln -sf $(MYLIB) $(DESTDIR)$(libdir)/$(MYLIBSO)     # -l:libclixon.so.3
 	ln -sf $(MYLIBSO) $(DESTDIR)$(libdir)/$(MYLIBLINK) # -l:libclixon.so
 

--- a/yang/Makefile.in
+++ b/yang/Makefile.in
@@ -58,8 +58,8 @@ distclean: clean
 install: $(YANGSPECS) 
 	echo $(DESTDIR)$(datarootdir)/clixon/clixon.mk
 	echo $(DESTDIR)$(clixon_DATADIR)
-	install -d $(DESTDIR)$(clixon_DATADIR)
-	install $(YANGSPECS) $(DESTDIR)$(clixon_DATADIR)
+	install -d -m 0755 $(DESTDIR)$(clixon_DATADIR)
+	install -m 0644 $(YANGSPECS) $(DESTDIR)$(clixon_DATADIR)
 
 uninstall: 
 	(cd $(DESTDIR)$(clixon_DATADIR); rm -rf $(YANGSPECS))


### PR DESCRIPTION
- Use 0755 for directories
- Use 0644 for libraries, includes and shared files
- Use -s (strip) parameter when installing binaries and libraries