### PR TITLE
include limits.h for non-Linux compatibility

### DIFF
--- a/apps/backend/clixon_backend_handle.c
+++ b/apps/backend/clixon_backend_handle.c
@@ -52,6 +52,7 @@
 #include <regex.h>
 #include <syslog.h>
 #include <netinet/in.h>
+#include <limits.h>
 
 /* cligen */
 #include <cligen/cligen.h>

--- a/apps/backend/clixon_backend_transaction.c
+++ b/apps/backend/clixon_backend_transaction.c
@@ -50,6 +50,7 @@
 #include <sys/types.h>
 #include <regex.h>
 #include <netinet/in.h>
+#include <limits.h>
 
 /* cligen */
 #include <cligen/cligen.h>

--- a/apps/restconf/restconf_main.c
+++ b/apps/restconf/restconf_main.c
@@ -54,6 +54,7 @@
 #include <syslog.h>
 #include <fcntl.h>
 #include <time.h>
+#include <limits.h>
 
 #include <signal.h>
 #include <sys/time.h>

--- a/apps/restconf/restconf_methods.c
+++ b/apps/restconf/restconf_methods.c
@@ -105,6 +105,7 @@ Mapping netconf error-tag -> status code
 #include <assert.h>
 #include <time.h>
 #include <signal.h>
+#include <limits.h>
 #include <sys/time.h>
 #include <sys/wait.h>
 


### PR DESCRIPTION
this change enables patchless compilation of clixon on FreeBSD
