### PR TITLE
Improve permissions and strip binaries (part 2)

### DIFF
--- a/apps/restconf/Makefile.in
+++ b/apps/restconf/Makefile.in
@@ -101,14 +101,14 @@ install:	install-lib $(APPL)
 	install -m 0755 -s $(APPL) $(DESTDIR)$(wwwdir)
 
 install-lib: $(MYLIB)
-	install -d $(DESTDIR)$(libdir) 
-	install $(MYLIB) $(DESTDIR)$(libdir) 
+	install -d -m 0755 $(DESTDIR)$(libdir)
+	install -m 0644 -s $(MYLIB) $(DESTDIR)$(libdir)
 	ln -sf $(MYLIB) $(DESTDIR)$(libdir)/$(MYLIBSO)     # -l:libclixon_restconf.so.2
 	ln -sf $(MYLIBSO) $(DESTDIR)$(libdir)/$(MYLIBLINK) # -l:libclixon_restconf.so
 
 install-include:	clixon_restconf.h
-	install -d $(DESTDIR)$(includedir)/clixon
-	install -m 644 $^ $(DESTDIR)$(includedir)/clixon
+	install -d -m 0755 $(DESTDIR)$(includedir)/clixon
+	install -m 0644 $^ $(DESTDIR)$(includedir)/clixon
 
 uninstall:
 	rm -f $(DESTDIR)$(wwwdir)/$(APPL)


### PR DESCRIPTION
- Use 0755 for directories
- Use 0644 for libraries, includes and shared files
- Use -s (strip) parameter when installing binaries and libraries