### PR TITLE
make specification of an operation compliant with RFC8040 section 3.6

### DIFF
--- a/lib/src/clixon_yang.c
+++ b/lib/src/clixon_yang.c
@@ -2137,16 +2137,12 @@ yang_abs_schema_nodeid(yang_spec    *yspec,
     }
     if (ymod == NULL){ /* Try with topnode */
 	if ((ys = yang_find_topnode(yspec, id, YC_SCHEMANODE)) == NULL){
-	    clicon_err(OE_YANG, 0, "Module with id:%s:%s not found", prefix,id);
+	    clicon_err(OE_YANG, 0, "Module with id:%s:%s not found (topnode)", prefix,id);
 	    goto done;
 	}
-	if ((ymod = ys_module(ys)) == NULL){
-	    clicon_err(OE_YANG, 0, "Module with id:%s:%s not found2", prefix,id);
-	    goto done;
-	}
-	if ((yprefix = yang_find((yang_node*)ymod, Y_PREFIX, NULL)) != NULL &&
-	    strcmp(yprefix->ys_argument, prefix) != 0){
-	    clicon_err(OE_YANG, 0, "Module with id:%s:%s not found", prefix,id);
+	if (((ymod = ys_module(ys)) == NULL) ||
+	    (strcmp(ymod->ys_argument, prefix) != 0)){
+	    clicon_err(OE_YANG, 0, "Module with id:%s:%s not found (module)", prefix,id);
 	    goto done;
 	}
     }


### PR DESCRIPTION
RFC 8030 section 3.6 indicates that an operation is identified by both module name and operation ID. The latest code used the prefix rather than the module name, which I believe is contrary to the RFC. This pull request removes the (possibly) erroneous check of the prefix and changes the code to require a module name match to resolve #31 
