### PR TITLE
Makefile in util directory didn't use LDFLAGS when building binaries

### DIFF
--- a/util/Makefile.in
+++ b/util/Makefile.in
@@ -80,16 +80,16 @@ clean:
 
 # APPS
 clixon_util_xml: clixon_util_xml.c $(MYLIB)
-	$(CC) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) $^ $(LIBS) -o $@
+	$(CC) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $^ $(LIBS) -o $@
 
 clixon_util_json: clixon_util_json.c $(MYLIB)
-	$(CC) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) $^ $(LIBS) -o $@
+	$(CC) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $^ $(LIBS) -o $@
 
 clixon_util_yang: clixon_util_yang.c $(MYLIB)
-	$(CC) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) $^ $(LIBS) -o $@
+	$(CC) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $^ $(LIBS) -o $@
 
 clixon_util_xpath: clixon_util_xpath.c $(MYLIB)
-	$(CC) $(INCLUDES) $(CPPFLAGS) @CFLAGS@ $^ $(LIBS) -o $@
+	$(CC) $(INCLUDES) $(CPPFLAGS) @CFLAGS@ $(LDFLAGS) $^ $(LIBS) -o $@
 
 distclean: clean
 	rm -f Makefile *~ .depend


### PR DESCRIPTION
This affects installations where the libraries are installed outside
the normal library search paths (e.g. FreeBSD puts ports libraries
in /usr/local/lib by default, which is not on the default lib path)