### PR TITLE
changes for FreeBSD compatibility

### DIFF
--- a/apps/netconf/netconf_main.c
+++ b/apps/netconf/netconf_main.c
@@ -294,7 +294,7 @@ static int
 timeout_fn(int s,
 	   void *arg)
 {
-    clicon_err(OE_EVENTS, ETIME, "User request timeout");
+    clicon_err(OE_EVENTS, ETIMEDOUT, "User request timeout");
     return -1; 
 }
 

--- a/lib/src/clixon_handle.c
+++ b/lib/src/clixon_handle.c
@@ -43,7 +43,9 @@
 #include <errno.h>
 #include <string.h>
 #include <assert.h>
- 
+
+#include <sys/time.h>
+
 #include <cligen/cligen.h>
 
 /* clicon */


### PR DESCRIPTION
ETIME shows in many distributions as "timer expired", I think ETIMEDOUT is more appropriate as it means "connection timed out" which is more correct for the intent of this error. Plus it allows compilation on FreeBSD. ETIMEDOUT is in both CentOS and Ubuntu.

add sys/time.h to clixon_handle.c. This is required to compile on FreeBSD, the header file exists in both Ubuntu and CentOS and so this change compiles in all three.
