### PR TITLE
FreeBSD compatibility & pedanticism patches 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.so.*
+*.so
 *_parse.tab.c
 *_parse.tab.h
 lex.*_parse.c

--- a/apps/netconf/netconf_main.c
+++ b/apps/netconf/netconf_main.c
@@ -312,7 +312,7 @@ static int
 timeout_fn(int s,
 	   void *arg)
 {
-    clicon_err(OE_EVENTS, ETIME, "User request timeout");
+    clicon_err(OE_EVENTS, ETIMEDOUT, "User request timeout");
     return -1; 
 }
 

--- a/lib/clixon/clixon_plugin.h
+++ b/lib/clixon/clixon_plugin.h
@@ -49,8 +49,6 @@
 /*
  * Types
  */
-/* Dynamicically loadable plugin object handle. @see return value of dlopen(3) */
-typedef void *plghndl_t;
 
 /*! Registered RPC callback function 
  * @param[in]  h       Clicon handle 

--- a/lib/clixon/clixon_yang.h
+++ b/lib/clixon/clixon_yang.h
@@ -281,7 +281,7 @@ int        yang_mandatory(yang_stmt *ys);
 int        yang_config(yang_stmt *ys);
 int        yang_spec_parse_module(clicon_handle h, const char *module,
 				  const char *revision, yang_spec *yspec);
-int        yang_spec_parse_file(clicon_handle h, const char *filename, yang_spec *yspec);
+int        yang_spec_parse_file(clicon_handle h, char *filename, yang_spec *yspec);
 int        yang_spec_load_dir(clicon_handle h, char *dir, yang_spec *yspec);
 cvec      *yang_arg2cvec(yang_stmt *ys, char *delimi);
 int        yang_key_match(yang_node *yn, char *name);

--- a/lib/src/clixon_yang.c
+++ b/lib/src/clixon_yang.c
@@ -69,6 +69,7 @@
 #include <sys/stat.h>
 #include <sys/param.h>
 #include <netinet/in.h>
+#include <libgen.h>
 
 /* cligen */
 #include <cligen/cligen.h>
@@ -2449,7 +2450,7 @@ yang_spec_parse_module(clicon_handle h,
  */
 int
 yang_spec_parse_file(clicon_handle h, 
-		     const char   *filename, 
+		     char   *filename, 
 		     yang_spec    *yspec)
 {
     int         retval = -1;


### PR DESCRIPTION
this pull request supersedes pull request #55 

use ETIMEDOUT rather than ETIME - this seems more the intent of its
usage here and it compiles under FreeBSD & Linux.
in yang_spec_parse_file() the function basename() is not declared,
the declaration is in libgen.h, so include it. also basename() takes
char * for its argument not const char *, yang_spec_parse_file()
has to be changed to char *filename to compile w/o warnings

these changes have been checked under both Linux and FreeBSD, merging them would simplify the FreeBSD port and remove warnings from both FreeBSD and Linux
