### PR TITLE
Startup extraxml file load fix

### DIFF
--- a/apps/backend/backend_main.c
+++ b/apps/backend/backend_main.c
@@ -678,7 +678,7 @@ main(int    argc,
     }
     /* Merge extra XML from file and reset function to running  
      */
-    if (status == STARTUP_OK && startup_mode != SM_NONE){
+    if (status == STARTUP_OK && startup_mode != SM_NONE && extraxml_file){
 	if ((ret = startup_extraxml(h, extraxml_file, cbret)) < 0)
 	    goto done;
 	if (ret2status(ret, &status) < 0)


### PR DESCRIPTION
When backend is started, startup_extraxml is called without any
checks. It causes "startup" config being overrided(not merged)
with "tmp" which is null due to nullprt file