### PR TITLE
fix problem validating leafref in state data referencing config data

### DIFF
--- a/apps/backend/backend_client.c
+++ b/apps/backend/backend_client.c
@@ -946,7 +946,7 @@ from_client_get(clicon_handle h,
 	 * metrged with state data, so zero-copy cant be used
 	 * Also, must use external namespace context here due to <filter stmt
 	 */
-	if (xmldb_get0(h, "running", nsc, xpath, 1, &xret, NULL) < 0) {
+	if (xmldb_get0(h, "running", nsc, NULL, 1, &xret, NULL) < 0) {
 	    if (netconf_operation_failed(cbret, "application", "read registry")< 0)
 		goto done;
 	    goto ok;


### PR DESCRIPTION
when the config data was merged in from_client_get() the xpath
excluded the config data, preventing the leafref from being validated.
change is to not filter the config data out at all.