### PR TITLE
Install include files within include target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -74,7 +74,7 @@ depend:
 install:  
 	for i in $(SUBDIRS) doc; \
 	do (cd $$i; $(MAKE) $(MFLAGS) $@)||exit 1; done; 
-	echo "Install for compilation by: make install-include"
+	$(MAKE) $(MFLAGS) install-include
 
 install-include:
 	for i in $(SUBDIRS) doc; \


### PR DESCRIPTION
should install include files with all the other stuff with 'make install' 

In DEB or RPM packages they have the concept of dev and user packages - this can be handled in the package creation scripts so should not break anything there.

Plus, this makes the FreeBSD port easier to do...