### PR TITLE
make xml2xpath1() less picky

### DIFF
--- a/lib/src/clixon_xml_map.c
+++ b/lib/src/clixon_xml_map.c
@@ -1503,8 +1503,7 @@ xml2xpath1(cxobj *x,
     char         *b;
     enum rfc_6020 keyword;
     
-    if ((xp = xml_parent(x)) != NULL &&
-	xml_spec(xp) != NULL)
+    if (xp = xml_parent(x))
 	xml2xpath1(xp, cb);
     /* XXX: sometimes there should be a /, sometimes not */
     cprintf(cb, "/%s", xml_name(x));


### PR DESCRIPTION
this function would never traverse up an XML tree from a node that
was not bound to a YANG model. this prevents the function from
working in some cases where it could.