### PR TITLE
Encode xpath select values with yang

### DIFF
--- a/lib/src/clixon_xml_sort.c
+++ b/lib/src/clixon_xml_sort.c
@@ -1343,6 +1343,7 @@ xml_find_index_yang(cxobj       *xp,
     cg_var    *ycv = NULL;
     int        i;
     char      *name;
+    char      *encstr;
     int        revert = 0;
     char      *indexvar = NULL;
 
@@ -1377,7 +1378,10 @@ xml_find_index_yang(cxobj       *xp,
 		revert++;
 		break;
 	    }
-	    cprintf(cb, "<%s>%s</%s>", kname, cv_string_get(cvi), kname);
+	    if (xml_chardata_encode(&encstr, "%s", cv_string_get(cvi)) < 0)
+		goto done;
+	    cprintf(cb, "<%s>%s</%s>", kname, encstr, kname);
+	    free(encstr);
 	    i++;
 	}
 	if (revert)
@@ -1390,7 +1394,10 @@ xml_find_index_yang(cxobj       *xp,
 	    goto done;
 	}
 	cvi = cvec_i(cvk, 0);
-	cprintf(cb, "<%s>%s</%s>", name, cv_string_get(cvi), name);
+	if (xml_chardata_encode(&encstr, "%s", cv_string_get(cvi)) < 0)
+	    goto done;
+	cprintf(cb, "<%s>%s</%s>", name, encstr, name);
+	free(encstr);
 	break;
     default:
 	cprintf(cb, "<%s/>", name);
@@ -1407,7 +1414,10 @@ xml_find_index_yang(cxobj       *xp,
 	    yang_flag_get(yi, YANG_FLAG_INDEX) == 0)
 	    goto revert;
 	cbuf_reset(cb);
-	cprintf(cb, "<%s><%s>%s</%s></%s>", name, iname, cv_string_get(cvi), iname, name);	
+	if (xml_chardata_encode(&encstr, "%s", cv_string_get(cvi)) < 0)
+	    goto done;
+	cprintf(cb, "<%s><%s>%s</%s></%s>", name, iname, encstr, iname, name);
+	free(encstr);
 	indexvar = iname;
     }
 #else


### PR DESCRIPTION
Search key values might contain xml meta-characters. These break
clixon_xml_parse_string() unless properly encoded.