### PR TITLE
Fixed filter-namespace not recognized correctly

### DIFF
--- a/apps/netconf/netconf_rpc.c
+++ b/apps/netconf/netconf_rpc.c
@@ -176,7 +176,7 @@ netconf_get_config(clicon_handle h,
      }
 
      /* ie <filter>...</filter> */
-     if ((xfilter = xpath_first(xn, NULL, "filter")) != NULL) 
+     if ((xfilter = xpath_first(xn, nsc, "%s%sfilter", prefix ? prefix : "", prefix ? ":" : "")) != NULL)
 	 ftype = xml_find_value(xfilter, "type");
      if (xfilter == NULL || ftype == NULL || strcmp(ftype, "xpath")==0){
 	 if (clicon_rpc_netconf_xml(h, xml_parent(xn), xret, NULL) < 0)
@@ -388,7 +388,7 @@ netconf_get(clicon_handle h,
      }
 
        /* ie <filter>...</filter> */
-     if ((xfilter = xpath_first(xn, NULL, "filter")) != NULL) 
+     if ((xfilter = xpath_first(xn, nsc, "%s%sfilter", prefix ? prefix : "", prefix ? ":" : "")) != NULL)
 	 ftype = xml_find_value(xfilter, "type");
      if (xfilter == NULL || ftype == NULL || strcmp(ftype, "xpath")==0){
 	 if (clicon_rpc_netconf_xml(h, xml_parent(xn), xret, NULL) < 0)

--- a/apps/netconf/netconf_rpc.c
+++ b/apps/netconf/netconf_rpc.c
@@ -164,6 +164,16 @@ netconf_get_config(clicon_handle h,
      int        retval = -1;
      cxobj     *xfilter; /* filter */
      char      *ftype = NULL;
+     cvec      *nsc = NULL;
+     char      *prefix = NULL;
+
+     if(xml_nsctx_node(xn, &nsc) < 0)
+         goto done;
+
+     /* Get prefix of netconf base namespace in the incoming message */
+     if (xml_nsctx_get_prefix(nsc, NETCONF_BASE_NAMESPACE, &prefix) == 0){
+         goto done;
+     }
 
      /* ie <filter>...</filter> */
      if ((xfilter = xpath_first(xn, NULL, "filter")) != NULL) 
@@ -193,6 +203,8 @@ netconf_get_config(clicon_handle h,
      }
     retval = 0;
  done:
+    if (nsc)
+        cvec_free(nsc);
     return retval;
 }
 
@@ -364,6 +376,16 @@ netconf_get(clicon_handle h,
      int        retval = -1;
      cxobj     *xfilter; /* filter */
      char      *ftype = NULL;
+     cvec      *nsc = NULL;
+     char      *prefix = NULL;
+
+     if(xml_nsctx_node(xn, &nsc) < 0)
+         goto done;
+
+     /* Get prefix of netconf base namespace in the incoming message */
+     if (xml_nsctx_get_prefix(nsc, NETCONF_BASE_NAMESPACE, &prefix) == 0){
+         goto done;
+     }
 
        /* ie <filter>...</filter> */
      if ((xfilter = xpath_first(xn, NULL, "filter")) != NULL) 
@@ -393,6 +415,8 @@ netconf_get(clicon_handle h,
      }
     retval = 0;
  done:
+    if(nsc)
+        cvec_free(nsc);	
     return retval;
 }
 


### PR DESCRIPTION
The "filter" node was not detected when an a namespace was used. The fix is similar to https://github.com/clicon/clixon/commit/d045e8abcec2699ac363947b0fe6061fab5794ba and related to bug #154 #143 