### PR TITLE
datastore_read: bind yang when reading from cache

### DIFF
--- a/lib/src/clixon_datastore_read.c
+++ b/lib/src/clixon_datastore_read.c
@@ -675,6 +675,10 @@ xmldb_get_cache(clicon_handle    h,
     else
 	x0t = de->de_xml;
 
+    if (yb == YB_MODULE && !xml_spec(x0t))
+	if (xml_bind_yang(x0t, YB_MODULE, yspec, NULL) < 0)
+	    goto done;
+
     /* Here x0t looks like: <config>...</config> */
     /* Given the xpath, return a vector of matches in xvec 
      * Can we do everything in one go?


### PR DESCRIPTION
The cached xml version might be missing the yang information. This
breaks netconf validation of the running database:

yangcli admin@192.168.0.1> validate source=startup

RPC Error Reply 3 for session 3:

rpc-reply {
  rpc-error {
    error-type application
    error-tag operation-failed
    error-severity error
    error-message 'No spec found radio-dn'
  }
}

Make sure that the cached database respects the yb parameter.