### PR TITLE
completing the function of hide for autocli-op in yang files 

### DIFF
--- a/apps/cli/cli_generate.c
+++ b/apps/cli/cli_generate.c
@@ -741,7 +741,7 @@ yang2cli_container(clicon_handle h,
     char         *helptext = NULL;
     char         *s;
     int           hide = 0;
-
+	char*             opext = NULL;
     /* If non-presence container && HIDE mode && only child is 
      * a list, then skip container keyword
      * See also xml2cli
@@ -756,6 +756,12 @@ yang2cli_container(clicon_handle h,
 	    if ((s = strstr(helptext, "\n\n")) != NULL)
 		*s = '\0';
 	    yang2cli_helptext(cb, helptext);
+	}
+	/* Look for autocli-op defined in clixon-lib.yang */
+	if (yang_extension_value(ys, "autocli-op", CLIXON_LIB_NS, &opext) < 0)
+		goto done;
+	if (opext != NULL && strcmp(opext, "hide") == 0){
+		cprintf(cb, ",hide");
 	}
 	if (cli_callback_generate(h, ys, cb) < 0)
 	    goto done;

--- a/apps/cli/cli_generate.c
+++ b/apps/cli/cli_generate.c
@@ -688,6 +688,10 @@ yang2cli_leaf(clicon_handle h,
 		cprintf(cb, ",hide{");
 		extralevel = 1;
 	    }
+		if (opext && strcmp(opext, "hide-database") == 0){
+		cprintf(cb, ",hide-database{");
+		extralevel = 1;
+		}
 	    if (yang2cli_var(h, ys, helptext, cb) < 0)
 		goto done;
 	}
@@ -695,6 +699,9 @@ yang2cli_leaf(clicon_handle h,
 	    if (opext && strcmp(opext, "hide") == 0){
 		cprintf(cb, ",hide");
 	    }
+		if (opext && strcmp(opext, "hide-database") == 0){
+		cprintf(cb, ",hide-database");
+		}
 	}
     }
     else{
@@ -763,6 +770,9 @@ yang2cli_container(clicon_handle h,
 	if (opext != NULL && strcmp(opext, "hide") == 0){
 		cprintf(cb, ",hide");
 	}
+	if (opext != NULL && strcmp(opext, "hide-database") == 0){
+		cprintf(cb, ",hide-database");
+	}
 	if (cli_callback_generate(h, ys, cb) < 0)
 	    goto done;
 	cprintf(cb, ";{\n");
@@ -820,6 +830,10 @@ yang2cli_list(clicon_handle      h,
 	cprintf(cb, ",hide");
 	extralevel = 1;
     }
+	if (opext != NULL && strcmp(opext, "hide-database") == 0){
+	cprintf(cb, ",hide-database");
+	extralevel = 1;
+	}
     if ((yd = yang_find(ys, Y_DESCRIPTION, NULL)) != NULL){
 	if ((helptext = strdup(yang_argument_get(yd))) == NULL){
 	    clicon_err(OE_UNIX, errno, "strdup");

--- a/lib/src/clixon_json.c
+++ b/lib/src/clixon_json.c
@@ -719,7 +719,15 @@ xml2json1_cbuf(cbuf                   *cb,
     yang_stmt       *ymod = NULL; /* yang module */
     int              commas;
     char            *modname = NULL;
+	char         *opext = NULL;
 
+	/* Look for autocli-op defined in clixon-lib.yang */
+	if (yang_extension_value(xml_spec(x), "autocli-op", CLIXON_LIB_NS, &opext) < 0) {
+		goto done;
+	}
+	if (opext != NULL && strcmp(opext, "hide") == 0) {
+		goto done;
+	}
     if ((ys = xml_spec(x)) != NULL){
 	if (ys_real_module(ys, &ymod) < 0)
 	    goto done;

--- a/lib/src/clixon_xml_io.c
+++ b/lib/src/clixon_xml_io.c
@@ -116,11 +116,18 @@ xml2file_recurse(FILE             *f,
     int    haselement;
     char  *val;
     char  *encstr = NULL; /* xml encoded string */
-    
+    char         *opext = NULL;
     if (x == NULL)
 	goto ok;
     name = xml_name(x);
     namespace = xml_prefix(x);
+	/* Look for autocli-op defined in clixon-lib.yang */
+	if (yang_extension_value(xml_spec(x), "autocli-op", CLIXON_LIB_NS, &opext) < 0) {
+		goto ok;
+	}
+	if (opext != NULL && strcmp(opext, "hide") == 0) {
+		goto ok;
+	}
     switch(xml_type(x)){
     case CX_BODY:
 	if ((val = xml_value(x)) == NULL) /* incomplete tree */

--- a/lib/src/clixon_xml_map.c
+++ b/lib/src/clixon_xml_map.c
@@ -160,6 +160,9 @@ xml2txt_recurse(FILE             *f,
 	if (opext != NULL && strcmp(opext, "hide") == 0) {
 		goto ok;
 	}
+	if (opext != NULL && strcmp(opext, "hide-database") == 0) {
+		goto ok;
+	}
     if (!children){ /* If no children print line */
 	switch (xml_type(x)){
 	case CX_BODY:
@@ -246,6 +249,9 @@ xml2cli_recurse(FILE              *f,
 		goto ok;
 	}
 	if (opext != NULL && strcmp(opext, "hide") == 0) {
+		goto ok;
+	}
+	if (opext != NULL && strcmp(opext, "hide-database") == 0) {
 		goto ok;
 	}
     if (xml_type(x)==CX_ATTR)

--- a/lib/src/clixon_xml_map.c
+++ b/lib/src/clixon_xml_map.c
@@ -240,7 +240,14 @@ xml2cli_recurse(FILE              *f,
     yang_stmt       *ys;
     int              match;
     char            *body;
-
+	char         *opext = NULL;
+	/* Look for autocli-op defined in clixon-lib.yang */
+	if (yang_extension_value(xml_spec(x), "autocli-op", CLIXON_LIB_NS, &opext) < 0) {
+		goto ok;
+	}
+	if (opext != NULL && strcmp(opext, "hide") == 0) {
+		goto ok;
+	}
     if (xml_type(x)==CX_ATTR)
 	goto ok;
     if ((ys = xml_spec(x)) == NULL)

--- a/lib/src/clixon_xml_map.c
+++ b/lib/src/clixon_xml_map.c
@@ -144,7 +144,7 @@ xml2txt_recurse(FILE             *f,
     cxobj *xc = NULL;
     int    children=0;
     int    retval = -1;
-
+	char         *opext = NULL;
     if (f == NULL || x == NULL || fn == NULL){
 	clicon_err(OE_XML, EINVAL, "f, x or fn is NULL");
 	goto done;
@@ -153,6 +153,13 @@ xml2txt_recurse(FILE             *f,
     while ((xc = xml_child_each(x, xc, -1)) != NULL)
 	if (xml_type(xc) == CX_ELMNT || xml_type(xc) == CX_BODY)
 	    children++;
+	/* Look for autocli-op defined in clixon-lib.yang */
+	if (yang_extension_value(xml_spec(x), "autocli-op", CLIXON_LIB_NS, &opext) < 0) {
+		goto ok;
+	}
+	if (opext != NULL && strcmp(opext, "hide") == 0) {
+		goto ok;
+	}
     if (!children){ /* If no children print line */
 	switch (xml_type(x)){
 	case CX_BODY:


### PR DESCRIPTION
1. Added the hide functionality to containers (until now it was only implemented for lists and leaves).

2. Added the functionality to showing the database (configuration and state), meaning, if there's a hide for a parent in a yang module, then you won't see it and its "offspring", no matter if it's state data or configuration. 