### PR TITLE
fix: Build breaks when using "--without-restconfig"

### DIFF
--- a/configure
+++ b/configure
@@ -5402,6 +5402,17 @@ cat >>confdefs.h <<_ACEOF
 #define WWWDIR "$wwwdir"
 _ACEOF
 
+else
+
+cat >>confdefs.h <<_ACEOF
+#define WWWUSER ""
+_ACEOF
+
+
+cat >>confdefs.h <<_ACEOF
+#define WWWDIR ""
+_ACEOF
+
 fi
 
 # Set default config file location

--- a/configure.ac
+++ b/configure.ac
@@ -251,6 +251,9 @@ if test "x${with_restconf}" != "x"; then
    AC_MSG_RESULT(www user is $wwwuser)	
    AC_DEFINE_UNQUOTED(WWWUSER, "$wwwuser", [WWW user for restconf daemon])
    AC_DEFINE_UNQUOTED(WWWDIR, "$wwwdir", [WWW dir for restconf daemon])
+else
+   AC_DEFINE_UNQUOTED(WWWUSER, "", [WWW user for restconf daemon])
+   AC_DEFINE_UNQUOTED(WWWDIR, "", [WWW dir for restconf daemon])
 fi
 
 # Set default config file location


### PR DESCRIPTION
When using "./configure --without-restconfig" the variables "WWWUSER" and "WWWDIR" are not defined, leading to a build failure. This change simply sets those variables to an empty string. Not sure if this is the correct way of doing it tho!