### PR TITLE
change localtime to localtime_r which is a thread-safe function

### DIFF
--- a/lib/src/clixon_log.c
+++ b/lib/src/clixon_log.c
@@ -171,13 +171,13 @@ static int
 flogtime(FILE *f)
 {
     struct timeval tv;
-    struct tm *tm;
+    struct tm tm;
 
     gettimeofday(&tv, NULL);
-    tm = localtime((time_t*)&tv.tv_sec);
+    localtime_r((time_t*)&tv.tv_sec, &tm);
     fprintf(f, "%s %2d %02d:%02d:%02d: ", 
-	    mon2name(tm->tm_mon), tm->tm_mday,
-	    tm->tm_hour, tm->tm_min, tm->tm_sec);
+	    mon2name(tm.tm_mon), tm.tm_mday,
+	    tm.tm_hour, tm.tm_min, tm.tm_sec);
     return 0;
 }
 


### PR DESCRIPTION
localtime isn't thread-safe and therefore, it caused crashes in our system, in certain cases. localtime_r is thread-safe.