### PR TITLE
Fixed memory allocation for `struct dirent`

### DIFF
--- a/lib/src/clixon_file.c
+++ b/lib/src/clixon_file.c
@@ -50,7 +50,8 @@
 #include <sys/param.h>
 #include <unistd.h>
 #include <netinet/in.h>
- 
+#include <stddef.h>
+
 /* cligen */
 #include <cligen/cligen.h>
 
@@ -103,6 +104,7 @@ clicon_file_dirent(const char     *dir,
    DIR           *dirp;
    int            res;
    int            nent;
+   int            direntStructSize;
    regex_t        re;
    char           errbuf[128];
    char           filename[MAXPATHLEN];
@@ -143,12 +145,13 @@ clicon_file_dirent(const char     *dir,
 	   if ((type & st.st_mode) == 0)
 	       continue;
        }
-       if ((tmp = realloc(new, (nent+1)*sizeof(*dvecp))) == NULL) {
+       direntStructSize = offsetof(struct dirent, d_name) + strlen(dent->d_name) + 1;
+       if ((tmp = realloc(new, (nent+1)*direntStructSize)) == NULL) {
 	   clicon_err(OE_UNIX, errno, "realloc");
 	   goto quit;
        }
        new = tmp;
-       memcpy(&new[nent], dent, sizeof(*dent));
+       memcpy(&new[nent], dent, direntStructSize);
        nent++;
 
    } /* while */


### PR DESCRIPTION
While porting clixon to the RTOS Blackberry QNX there was memory corruption while reading the yang models from the disk.
Debugging led to the function `clicon_file_dirent` in `clixon_file.c` in which the `struct dirent` is copied into an array.
According to the UNIX `struct dirent` [documentation](https://man7.org/linux/man-pages/man0/dirent.h.0p.html):
>  The name of an array of char of an unspecified size should not be
>  used as an lvalue. Use of:
>
>         sizeof(d_name)
>
>  is incorrect; use:
>
>         strlen(d_name)
>
>  instead.

I adjusted the memory allocation to take the `strlen(dent->d_name)` into account.