### PR TITLE
Remove hardcoded path to diff binary

### DIFF
--- a/apps/cli/cli_common.c
+++ b/apps/cli/cli_common.c
@@ -701,7 +701,7 @@ compare_xmls(cxobj *xc1,
 	clicon_err(OE_CFG, errno, "cbuf_new");
 	goto done;
     }
-    cprintf(cb, "/usr/bin/diff -dU 1 %s %s |  grep -v @@ | sed 1,2d",
+    cprintf(cb, "diff -dU 1 %s %s |  grep -v @@ | sed 1,2d",
 	    filename1, filename2);
     if (system(cbuf_get(cb)) < 0)
 	goto done;


### PR DESCRIPTION
Like other programs, diff can and should be located using PATH.
This fixes compare_dbs() on non-FHS systems, like NixOS.