### PR TITLE
Fixed SH_SUFFIX

### DIFF
--- a/apps/netconf/Makefile.in
+++ b/apps/netconf/Makefile.in
@@ -53,7 +53,7 @@ sysconfdir	= @sysconfdir@
 includedir	= @includedir@
 HOST_VENDOR     = @host_vendor@
 
-SH_SUFFIX	= .so
+SH_SUFFIX	= @SH_SUFFIX@
 CLIXON_MAJOR    = @CLIXON_VERSION_MAJOR@
 CLIXON_MINOR    = @CLIXON_VERSION_MINOR@
 


### PR DESCRIPTION
In commit https://github.com/clicon/clixon/commit/5a875e3152d5647e01f4ed5c3551066273c719a1#diff-4d7a9475650e34ce4598d7562b0d77b9de0d265cc7dac7c5a0bad8451f5fab11 you've replaced the `SH_SUFFIX` variable with a static value of `.so`. This PR is reverting this change.