### PR TITLE
Fixed CFLags for debug mode

### DIFF
--- a/configure
+++ b/configure
@@ -4325,7 +4325,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: debug is $ac_enable_debug" >&5
 $as_echo "debug is $ac_enable_debug" >&6; }
 if test "$ac_enable_debug" = "yes"; then
-   CFLAGS="-g -Wall"
+   CFLAGS="$CFLAGS -g -Wall"
    INSTALLFLAGS=""
 fi
 
@@ -4333,6 +4333,8 @@ fi
 $as_echo "CPPFLAGS is $CPPFLAGS" >&6; }
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: CFLAGS is $CFLAGS" >&5
 $as_echo "CFLAGS is $CFLAGS" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: LDFLAGS is $LDFLAGS" >&5
+$as_echo "LDFLAGS is $LDFLAGS" >&6; }
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: INSTALLFLAGS is $INSTALLFLAGS" >&5
 $as_echo "INSTALLFLAGS is $INSTALLFLAGS" >&6; }
 

--- a/configure.ac
+++ b/configure.ac
@@ -123,12 +123,13 @@ AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],[Build with debug symbols, 
 
 AC_MSG_RESULT(debug is $ac_enable_debug)	
 if test "$ac_enable_debug" = "yes"; then
-   CFLAGS="-g -Wall"
+   CFLAGS="$CFLAGS -g -Wall"
    INSTALLFLAGS=""	
 fi
 
 AC_MSG_RESULT(CPPFLAGS is $CPPFLAGS)	
 AC_MSG_RESULT(CFLAGS is $CFLAGS)
+AC_MSG_RESULT(LDFLAGS is $LDFLAGS)
 AC_MSG_RESULT(INSTALLFLAGS is $INSTALLFLAGS)	
 
 AC_PROG_YACC


### PR DESCRIPTION
Fixing the behavior when using the `--enable-debug` flag -> the `CFLAGS` variable get's overwritten. Also logging out the `LDFLAGS` variable for debugging purposes.