### PR TITLE
Added --without-sigaction option

### DIFF
--- a/configure
+++ b/configure
@@ -724,6 +724,7 @@ enable_evhtp
 enable_nghttp2
 with_configfile
 with_libxml2
+with_sigaction
 with_yang_installdir
 with_opt_yang_installdir
 '
@@ -1384,6 +1385,7 @@ Optional Packages:
   --without-restconf      Disable restconf altogether
   --with-configfile=FILE  Set default path to config file
   --with-libxml2          Use gnome/libxml2 regex engine
+  --without-sigaction     Don't use sigaction
   --with-yang-installdir=DIR
                           Install Clixon yang files here (default:
                           ${prefix}/share/clixon)
@@ -5565,7 +5567,7 @@ fi
 fi
 
 #
-for ac_func in inet_aton sigaction sigvec strlcpy strsep strndup alphasort versionsort getpeereid setns getresuid
+for ac_func in inet_aton sigvec strlcpy strsep strndup alphasort versionsort getpeereid setns getresuid
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
@@ -5577,6 +5579,31 @@ _ACEOF
 fi
 done
 
+
+# Check for --without-sigaction parameter
+
+# Check whether --with-sigaction was given.
+if test "${with_sigaction+set}" = set; then :
+  withval=$with_sigaction;
+else
+  with_sigaction=yes
+
+fi
+
+
+if test "x${with_sigaction}" == "xyes"; then
+   for ac_func in sigaction
+do :
+  ac_fn_c_check_func "$LINENO" "sigaction" "ac_cv_func_sigaction"
+if test "x$ac_cv_func_sigaction" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SIGACTION 1
+_ACEOF
+
+fi
+done
+
+fi
 
 # Checks for getsockopt options for getting unix socket peer credentials on
 # Linux

--- a/configure.ac
+++ b/configure.ac
@@ -298,7 +298,19 @@ if test "${with_libxml2}"; then
 fi 
 
 #
-AC_CHECK_FUNCS(inet_aton sigaction sigvec strlcpy strsep strndup alphasort versionsort getpeereid setns getresuid)
+AC_CHECK_FUNCS(inet_aton sigvec strlcpy strsep strndup alphasort versionsort getpeereid setns getresuid)
+
+# Check for --without-sigaction parameter
+AC_ARG_WITH(
+	[sigaction],
+	[AS_HELP_STRING([--without-sigaction], [Don't use sigaction])],
+	[],
+	[with_sigaction=yes]
+)
+
+if test "x${with_sigaction}" == "xyes"; then
+   AC_CHECK_FUNCS(sigaction)
+fi 
 
 # Checks for getsockopt options for getting unix socket peer credentials on
 # Linux


### PR DESCRIPTION
Even though QNX support the sigaction function, it does not support the `SA_RESTART` mode. The additional flag in the configure script allows passing `--without-sigaction` to disable the sigaction logic.