### PR TITLE
Ability to not show entire modules in cli by defining them in config file

### DIFF
--- a/lib/clixon/clixon_json.h
+++ b/lib/clixon/clixon_json.h
@@ -48,6 +48,7 @@ int xml2json_cbuf(cbuf *cb, cxobj *x, int pretty);
 int xml2json_cbuf_vec(cbuf *cb, cxobj **vec, size_t veclen, int pretty);
 int xml2json(FILE *f, cxobj *x, int pretty);
 int xml2json_cb(FILE *f, cxobj *x, int pretty, clicon_output_cb *fn);
+int xml2json_cli_show(cxobj *x, char** exvec, int nexvec);
 int json_print(FILE *f, cxobj *x);
 int xml2json_vec(FILE *f, cxobj **vec, size_t veclen, int pretty);
 int clixon_json_parse_string(char *str, yang_bind yb, yang_stmt *yspec, cxobj **xt, cxobj **xret);

--- a/yang/clixon/clixon-config@2021-11-11.yang
+++ b/yang/clixon/clixon-config@2021-11-11.yang
@@ -675,6 +675,15 @@ module clixon-config {
                  The value can be a list of space separated module names";
 	    default "clixon-restconf";
 	}
+	leaf CLICON_CLI_SHOW_EXCLUDE {
+	    type string;
+	    description
+		"List of module names that should not be showed in cli from
+                 Example: 
+                    <CLICON_CLI_SHOW_EXCLUDE>clixon-restconf</CLICON_CLI_SHOW_EXCLUDE> 
+                 means that cli will be able to show all modules except for clixon-restconf.yang
+                 The value can be a list of space separated module names";
+	}
 	leaf CLICON_CLI_VARONLY {
 	    type int32;
 	    default 1;


### PR DESCRIPTION
Let's say that we have the following yang files module1.yang and module2.yang.
`module module1 {
....
}`
`module module2 {
....
}`

If one doesn't want these modules to show in cli then he needs to define them in the config file as following 
`<CLICON_CLI_SHOW_EXCLUDE>module1 module2</CLICON_CLI_SHOW_EXCLUDE>`

Modules can be separated by space in config file.