### PR TITLE
Convert int64, uint64 and decimal64 to string in xml to json

### DIFF
--- a/lib/src/clixon_json.c
+++ b/lib/src/clixon_json.c
@@ -587,15 +587,25 @@ xml2json_encode_leafs(cxobj     *xb,
 	    else
 		cprintf(cb, "%s", body);
 	    break;
+	case CGV_INT64:
+	case CGV_UINT64:
+	case CGV_DEC64:
+		// [RFC7951] JSON Encoding of YANG Data
+		// 6.1 Numeric Types - A value of the "int64", "uint64", or "decimal64" type is represented as a JSON string
+		if (yang_keyword_get(yp) == Y_LEAF_LIST && xml_child_nr_type(xml_parent(xp), CX_ELMNT) == 1) {
+			cprintf(cb, "[%s]", body);
+		}
+		else {
+			cprintf(cb, "%s", body);
+		}
+		quote = 1;
+		break;
 	case CGV_INT8:
 	case CGV_INT16:
 	case CGV_INT32:
-	case CGV_INT64:
 	case CGV_UINT8:
 	case CGV_UINT16:
 	case CGV_UINT32:
-	case CGV_UINT64:
-	case CGV_DEC64:
 	case CGV_BOOL:
 	    cprintf(cb, "%s", body);
 	    quote = 0;

--- a/test/test_restconf_op.sh
+++ b/test/test_restconf_op.sh
@@ -107,7 +107,7 @@ new "restconf POST initial tree"
 expectpart "$(curl $CURLOPTS -X POST -H "Content-Type: application/yang-data+json" -d '{"example:cont1":{"interface":{"name":"local0","type":"regular"}}}' $RCPROTO://localhost/restconf/data)" 0 "HTTP/$HVER 201"
 
 new "restconf POST top without namespace"
-expectpart "$(curl $CURLOPTS -X POST -H "Content-Type: application/yang-data+json" -d '{"cont1":{"interface":{"name":"local0","type":"regular"}}}' $RCPROTO://localhost/restconf/data)" 0 "HTTP/$HVER 400" '{"ietf-restconf:errors":{"error":{"error-type":"rpc","error-tag":"malformed-message","error-severity":"error","error-message":"Top-level JSON object cont1 is not qualified with namespace which is a MUST according to RFC 7951"}}}'
+expectpart "$(curl $CURLOPTS -X POST -H "Content-Type: application/yang-data+json" -d '{"cont1":{"interface":{"name":"local0","type":"regular"}}}' $RCPROTO://localhost/restconf/data)" 0 "HTTP/$HVER 400" '{"ietf-restconf:errors":{"error":{"error-type":"rpc","error-tag":"malformed-message","error-severity":"error","error-message":"Top-level JSON object cont1 is not qualified with namespace which is a MUST according to RFC 7951"}}}'
 
 new "restconf GET datastore initial"
 expectpart "$(curl $CURLOPTS -X GET $RCPROTO://localhost/restconf/data/example:cont1)" 0 "HTTP/$HVER 200" '{"example:cont1":{"interface":\[{"name":"local0","type":"regular"}\]}}'
@@ -210,10 +210,10 @@ expectpart "$(curl $CURLOPTS -H "Accept: application/yang-data+xml" -X GET $RCPR
 
 #--------------- json type tests
 new "restconf POST type x3 POST"
-expectpart "$(curl $CURLOPTS -X POST -H "Content-Type: application/yang-data+json" -d '{"example:types":{"tint":42,"tdec64":42.123,"tbool":false,"tstr":"str"}}' $RCPROTO://localhost/restconf/data)" 0 "HTTP/$HVER 201" "Location: $RCPROTO://localhost/restconf/data/example:types"
+expectpart "$(curl $CURLOPTS -X POST -H "Content-Type: application/yang-data+json" -d '{"example:types":{"tint":42,"tdec64":"42.123","tbool":false,"tstr":"str"}}' $RCPROTO://localhost/restconf/data)" 0 "HTTP/$HVER 201" "Location: $RCPROTO://localhost/restconf/data/example:types"
 
 new "restconf POST type x3 GET"
-expectpart "$(curl $CURLOPTS -X GET $RCPROTO://localhost/restconf/data/example:types)" 0 "HTTP/$HVER 200" '{"example:types":{"tint":42,"tdec64":42.123,"tbool":false,"tstr":"str"}}'
+expectpart "$(curl $CURLOPTS -X GET $RCPROTO://localhost/restconf/data/example:types)" 0 "HTTP/$HVER 200" '{"example:types":{"tint":42,"tdec64":"42.123","tbool":false,"tstr":"str"}}'
 
 if [ $RC -ne 0 ]; then
     new "Kill restconf daemon"


### PR DESCRIPTION
Convert int64, uint64 and decimal64 to string in xml to json convertion (regarding to RFC7951):

`A value of the "int64", "uint64", or "decimal64" type is represented
   as a JSON string whose content is the lexical representation of the
   corresponding YANG type as specified in Sections [9.2.1](https://datatracker.ietf.org/doc/html/rfc7951#section-9.2.1) and [9.3.1](https://datatracker.ietf.org/doc/html/rfc7951#section-9.3.1) of
   [[RFC7950](https://datatracker.ietf.org/doc/html/rfc7950)].`

