### PR TITLE
Update FAQ.md hello world example url

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -74,7 +74,7 @@ Run the Clixon main example, in the [example](../example) directory or [examples
 
 ## Hello world?
 
-One of the examples is [a hello world example](https://github.com/clicon/clixon-examples/hello). Please start with that.
+One of the examples is [a hello world example](https://github.com/clicon/clixon-examples/tree/master/hello). Please start with that.
 
 ## How do you build and install Clixon?
 Clixon: 


### PR DESCRIPTION
This massive PR fixes the link to the `hello world` example in the FAQ.md.  Other links in the file were checked for correctness.