### PR TITLE
Fix cligen dir

### DIFF
--- a/config-aux/install-sh
+++ b/config-aux/install-sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # install - install a program, script, or datafile
 
-scriptversion=2014-09-12.12; # UTC
+scriptversion=2020-11-14.01; # UTC
 
 # This originates from X11R5 (mit/util/scripts/install.sh), which was
 # later released in X11R6 (xc/config/util/install.sh) with the
@@ -69,6 +69,11 @@ posix_mkdir=
 # Desired mode of installed file.
 mode=0755
 
+# Create dirs (including intermediate dirs) using mode 755.
+# This is like GNU 'install' as of coreutils 8.32 (2020).
+mkdir_umask=22
+
+backupsuffix=
 chgrpcmd=
 chmodcmd=$chmodprog
 chowncmd=
@@ -99,18 +104,28 @@ Options:
      --version  display version info and exit.
 
   -c            (ignored)
-  -C            install only if different (preserve the last data modification time)
+  -C            install only if different (preserve data modification time)
   -d            create directories instead of installing files.
   -g GROUP      $chgrpprog installed files to GROUP.
   -m MODE       $chmodprog installed files to MODE.
   -o USER       $chownprog installed files to USER.
+  -p            pass -p to $cpprog.
   -s            $stripprog installed files.
+  -S SUFFIX     attempt to back up existing files, with suffix SUFFIX.
   -t DIRECTORY  install into DIRECTORY.
   -T            report an error if DSTFILE is a directory.
 
 Environment variables override the default commands:
   CHGRPPROG CHMODPROG CHOWNPROG CMPPROG CPPROG MKDIRPROG MVPROG
   RMPROG STRIPPROG
+
+By default, rm is invoked with -f; when overridden with RMPROG,
+it's up to you to specify -f if you want it.
+
+If -S is not specified, no backups are attempted.
+
+Email bug reports to bug-automake@gnu.org.
+Automake home page: https://www.gnu.org/software/automake/
 "
 
 while test $# -ne 0; do
@@ -137,7 +152,12 @@ while test $# -ne 0; do
     -o) chowncmd="$chownprog $2"
         shift;;
 
+    -p) cpprog="$cpprog -p";;
+
     -s) stripcmd=$stripprog;;
+
+    -S) backupsuffix="$2"
+        shift;;
 
     -t)
         is_target_a_directory=always
@@ -255,6 +275,10 @@ do
     dstdir=$dst
     test -d "$dstdir"
     dstdir_status=$?
+    # Don't chown directories that already exist.
+    if test $dstdir_status = 0; then
+      chowncmd=""
+    fi
   else
 
     # Waiting for this to be detected by the "$cpprog $src $dsttmp" command
@@ -271,15 +295,18 @@ do
     fi
     dst=$dst_arg
 
-    # If destination is a directory, append the input filename; won't work
-    # if double slashes aren't ignored.
+    # If destination is a directory, append the input filename.
     if test -d "$dst"; then
       if test "$is_target_a_directory" = never; then
         echo "$0: $dst_arg: Is a directory" >&2
         exit 1
       fi
       dstdir=$dst
-      dst=$dstdir/`basename "$src"`
+      dstbase=`basename "$src"`
+      case $dst in
+	*/) dst=$dst$dstbase;;
+	*)  dst=$dst/$dstbase;;
+      esac
       dstdir_status=0
     else
       dstdir=`dirname "$dst"`
@@ -288,27 +315,16 @@ do
     fi
   fi
 
+  case $dstdir in
+    */) dstdirslash=$dstdir;;
+    *)  dstdirslash=$dstdir/;;
+  esac
+
   obsolete_mkdir_used=false
 
   if test $dstdir_status != 0; then
     case $posix_mkdir in
       '')
-        # Create intermediate dirs using mode 755 as modified by the umask.
-        # This is like FreeBSD 'install' as of 1997-10-28.
-        umask=`umask`
-        case $stripcmd.$umask in
-          # Optimize common cases.
-          *[2367][2367]) mkdir_umask=$umask;;
-          .*0[02][02] | .[02][02] | .[02]) mkdir_umask=22;;
-
-          *[0-7])
-            mkdir_umask=`expr $umask + 22 \
-              - $umask % 100 % 40 + $umask % 20 \
-              - $umask % 10 % 4 + $umask % 2
-            `;;
-          *) mkdir_umask=$umask,go-w;;
-        esac
-
         # With -d, create the new directory with the user-specified mode.
         # Otherwise, rely on $mkdir_umask.
         if test -n "$dir_arg"; then
@@ -318,50 +334,49 @@ do
         fi
 
         posix_mkdir=false
-        case $umask in
-          *[123567][0-7][0-7])
-            # POSIX mkdir -p sets u+wx bits regardless of umask, which
-            # is incompatible with FreeBSD 'install' when (umask & 300) != 0.
-            ;;
-          *)
-            # $RANDOM is not portable (e.g. dash);  use it when possible to
-            # lower collision chance
-            tmpdir=${TMPDIR-/tmp}/ins$RANDOM-$$
-            trap 'ret=$?; rmdir "$tmpdir/a/b" "$tmpdir/a" "$tmpdir" 2>/dev/null; exit $ret' 0
+	# The $RANDOM variable is not portable (e.g., dash).  Use it
+	# here however when possible just to lower collision chance.
+	tmpdir=${TMPDIR-/tmp}/ins$RANDOM-$$
 
-            # As "mkdir -p" follows symlinks and we work in /tmp possibly;  so
-            # create the $tmpdir first (and fail if unsuccessful) to make sure
-            # that nobody tries to guess the $tmpdir name.
-            if (umask $mkdir_umask &&
-                $mkdirprog $mkdir_mode "$tmpdir" &&
-                exec $mkdirprog $mkdir_mode -p -- "$tmpdir/a/b") >/dev/null 2>&1
-            then
-              if test -z "$dir_arg" || {
-                   # Check for POSIX incompatibilities with -m.
-                   # HP-UX 11.23 and IRIX 6.5 mkdir -m -p sets group- or
-                   # other-writable bit of parent directory when it shouldn't.
-                   # FreeBSD 6.1 mkdir -m -p sets mode of existing directory.
-                   test_tmpdir="$tmpdir/a"
-                   ls_ld_tmpdir=`ls -ld "$test_tmpdir"`
-                   case $ls_ld_tmpdir in
-                     d????-?r-*) different_mode=700;;
-                     d????-?--*) different_mode=755;;
-                     *) false;;
-                   esac &&
-                   $mkdirprog -m$different_mode -p -- "$test_tmpdir" && {
-                     ls_ld_tmpdir_1=`ls -ld "$test_tmpdir"`
-                     test "$ls_ld_tmpdir" = "$ls_ld_tmpdir_1"
-                   }
-                 }
-              then posix_mkdir=:
-              fi
-              rmdir "$tmpdir/a/b" "$tmpdir/a" "$tmpdir"
-            else
-              # Remove any dirs left behind by ancient mkdir implementations.
-              rmdir ./$mkdir_mode ./-p ./-- "$tmpdir" 2>/dev/null
-            fi
-            trap '' 0;;
-        esac;;
+	trap '
+	  ret=$?
+	  rmdir "$tmpdir/a/b" "$tmpdir/a" "$tmpdir" 2>/dev/null
+	  exit $ret
+	' 0
+
+	# Because "mkdir -p" follows existing symlinks and we likely work
+	# directly in world-writeable /tmp, make sure that the '$tmpdir'
+	# directory is successfully created first before we actually test
+	# 'mkdir -p'.
+	if (umask $mkdir_umask &&
+	    $mkdirprog $mkdir_mode "$tmpdir" &&
+	    exec $mkdirprog $mkdir_mode -p -- "$tmpdir/a/b") >/dev/null 2>&1
+	then
+	  if test -z "$dir_arg" || {
+	       # Check for POSIX incompatibilities with -m.
+	       # HP-UX 11.23 and IRIX 6.5 mkdir -m -p sets group- or
+	       # other-writable bit of parent directory when it shouldn't.
+	       # FreeBSD 6.1 mkdir -m -p sets mode of existing directory.
+	       test_tmpdir="$tmpdir/a"
+	       ls_ld_tmpdir=`ls -ld "$test_tmpdir"`
+	       case $ls_ld_tmpdir in
+		 d????-?r-*) different_mode=700;;
+		 d????-?--*) different_mode=755;;
+		 *) false;;
+	       esac &&
+	       $mkdirprog -m$different_mode -p -- "$test_tmpdir" && {
+		 ls_ld_tmpdir_1=`ls -ld "$test_tmpdir"`
+		 test "$ls_ld_tmpdir" = "$ls_ld_tmpdir_1"
+	       }
+	     }
+	  then posix_mkdir=:
+	  fi
+	  rmdir "$tmpdir/a/b" "$tmpdir/a" "$tmpdir"
+	else
+	  # Remove any dirs left behind by ancient mkdir implementations.
+	  rmdir ./$mkdir_mode ./-p ./-- "$tmpdir" 2>/dev/null
+	fi
+	trap '' 0;;
     esac
 
     if
@@ -372,7 +387,7 @@ do
     then :
     else
 
-      # The umask is ridiculous, or mkdir does not conform to POSIX,
+      # mkdir does not conform to POSIX,
       # or it failed possibly due to a race condition.  Create the
       # directory the slow way, step by step, checking for races as we go.
 
@@ -401,7 +416,7 @@ do
           prefixes=
         else
           if $posix_mkdir; then
-            (umask=$mkdir_umask &&
+            (umask $mkdir_umask &&
              $doit_exec $mkdirprog $mkdir_mode -p -- "$dstdir") && break
             # Don't fail if two instances are running concurrently.
             test -d "$prefix" || exit 1
@@ -434,14 +449,25 @@ do
   else
 
     # Make a couple of temp file names in the proper directory.
-    dsttmp=$dstdir/_inst.$$_
-    rmtmp=$dstdir/_rm.$$_
+    dsttmp=${dstdirslash}_inst.$$_
+    rmtmp=${dstdirslash}_rm.$$_
 
     # Trap to clean up those temp files at exit.
     trap 'ret=$?; rm -f "$dsttmp" "$rmtmp" && exit $ret' 0
 
     # Copy the file name to the temp name.
-    (umask $cp_umask && $doit_exec $cpprog "$src" "$dsttmp") &&
+    (umask $cp_umask &&
+     { test -z "$stripcmd" || {
+	 # Create $dsttmp read-write so that cp doesn't create it read-only,
+	 # which would cause strip to fail.
+	 if test -z "$doit"; then
+	   : >"$dsttmp" # No need to fork-exec 'touch'.
+	 else
+	   $doit touch "$dsttmp"
+	 fi
+       }
+     } &&
+     $doit_exec $cpprog "$src" "$dsttmp") &&
 
     # and set any options; do chmod last to preserve setuid bits.
     #
@@ -467,6 +493,13 @@ do
     then
       rm -f "$dsttmp"
     else
+      # If $backupsuffix is set, and the file being installed
+      # already exists, attempt a backup.  Don't worry if it fails,
+      # e.g., if mv doesn't support -f.
+      if test -n "$backupsuffix" && test -f "$dst"; then
+        $doit $mvcmd -f "$dst" "$dst$backupsuffix" 2>/dev/null
+      fi
+
       # Rename the file to the real destination.
       $doit $mvcmd -f "$dsttmp" "$dst" 2>/dev/null ||
 
@@ -481,9 +514,9 @@ do
         # file should still install successfully.
         {
           test ! -f "$dst" ||
-          $doit $rmcmd -f "$dst" 2>/dev/null ||
+          $doit $rmcmd "$dst" 2>/dev/null ||
           { $doit $mvcmd -f "$dst" "$rmtmp" 2>/dev/null &&
-            { $doit $rmcmd -f "$rmtmp" 2>/dev/null; :; }
+            { $doit $rmcmd "$rmtmp" 2>/dev/null; :; }
           } ||
           { echo "$0: cannot unlink or rename $dst" >&2
             (exit 1); exit 1
@@ -500,9 +533,9 @@ do
 done
 
 # Local variables:
-# eval: (add-hook 'write-file-hooks 'time-stamp)
+# eval: (add-hook 'before-save-hook 'time-stamp)
 # time-stamp-start: "scriptversion="
 # time-stamp-format: "%:y-%02m-%02d.%02H"
-# time-stamp-time-zone: "UTC"
+# time-stamp-time-zone: "UTC0"
 # time-stamp-end: "; # UTC"
 # End:

--- a/configure
+++ b/configure
@@ -648,6 +648,7 @@ ac_includes_default="\
 ac_header_c_list=
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+CLIGEN_DIR
 WC_BIN
 TAIL_BIN
 GREP
@@ -685,7 +686,6 @@ INSTALL_DATA
 INSTALL_SCRIPT
 INSTALL_PROGRAM
 INCLUDES
-CLIGEN_PREFIX
 CLIXON_VERSION_MINOR
 CLIXON_VERSION_MAJOR
 CLIXON_VERSION_STRING
@@ -2825,13 +2825,6 @@ else
    : ${CFLAGS="-O2 -Wall"}
 fi
 
-# Check CLIgen
-if test "$prefix" = "NONE"; then
-	CLIGEN_PREFIX="$ac_default_prefix"
-else
-	CLIGEN_PREFIX="$prefix"
-fi
-
 ac_config_headers="$ac_config_headers include/clixon_config.h lib/clixon/clixon.h"
 
 
@@ -4005,7 +3998,6 @@ test -n "$target_alias" &&
 
 # AC_SUBST(var) makes @var@ appear in makefiles.
 # clixon versions spread to Makefile's (.so files) and variable in build.c
-
 
 
 
@@ -5903,6 +5895,10 @@ if test "$prefix" = "NONE"; then
      prefix=${ac_default_prefix}
 fi
 
+if test "$exec_prefix" = "NONE"; then
+     exec_prefix=${prefix}
+fi
+
 # Postfix for shared libs
 SH_SUFFIX=".so"
 # Postfix for static libs
@@ -5914,16 +5910,15 @@ LIBSTATIC_SUFFIX=".a"
 if test ${with_cligen+y}
 then :
   withval=$with_cligen;
+  CLIGEN_DIR="$withval"
+
 fi
 
+
 if test -n "${CLIGEN_DIR}" -a -d "${CLIGEN_DIR}"; then
-        with_cligen=${CLIGEN_DIR}
-fi
-if test -d "${with_cligen}"; then
-  echo "Using CLIGEN here: ${with_cligen}"
-  CPPFLAGS="-I${with_cligen}/include ${CPPFLAGS}"
-  LDFLAGS="-L${with_cligen}/lib ${LDFLAGS}"
-  test -d "$with_cligen" && CLIGEN_PREFIX="$with_cligen"
+    echo "Using CLIGEN here: ${CLIGEN_DIR}"
+    CPPFLAGS="-I${CLIGEN_DIR}$(eval echo ${includedir}) ${CPPFLAGS}"
+    LDFLAGS="-L${CLIGEN_DIR}$(eval echo ${libdir}) ${LDFLAGS}"
 fi
 
 # Disable/enable yang patch
@@ -6873,10 +6868,8 @@ fi
 # Expand for easy replacement in example/main/example.xml.in
 # Special case is $libdir, which is composed from $exec_prefix
 test "x$prefix" = xNONE && prefix=$ac_default_prefix
-test "x$exec_prefix" = xNONE && exec_prefix='${prefix}'
 SYSCONFDIR=`eval echo $sysconfdir`
 LIBDIR=`eval echo $libdir`
-LIBDIR=`eval echo $LIBDIR`
 LOCALSTATEDIR=`eval echo $localstatedir`
 
 ac_config_files="$ac_config_files Makefile lib/Makefile lib/src/Makefile lib/clixon/Makefile apps/Makefile apps/cli/Makefile apps/backend/Makefile apps/netconf/Makefile apps/restconf/Makefile apps/snmp/Makefile include/Makefile etc/Makefile etc/clixonrc example/Makefile example/main/Makefile example/main/example.xml docker/Makefile docker/clixon-dev/Makefile docker/example/Makefile docker/test/Makefile util/Makefile yang/Makefile yang/clixon/Makefile yang/mandatory/Makefile doc/Makefile test/Makefile test/config.sh test/cicd/Makefile test/vagrant/Makefile"

--- a/configure.ac
+++ b/configure.ac
@@ -179,15 +179,14 @@ SH_SUFFIX=".so"
 LIBSTATIC_SUFFIX=".a"
 
 # This is for cligen
-AC_ARG_WITH([cligen], AS_HELP_STRING([--with-cligen=dir],[Use CLIGEN installation in this dir]))
+AC_ARG_WITH([cligen], [AS_HELP_STRING([--with-cligen=dir], [Use CLIGEN installation in this dir])], [
+  CLIGEN_DIR="$withval"
+])
+AC_SUBST(CLIGEN_DIR)
 if test -n "${CLIGEN_DIR}" -a -d "${CLIGEN_DIR}"; then
-        with_cligen=${CLIGEN_DIR}
-fi
-if test -d "${with_cligen}"; then
-  echo "Using CLIGEN here: ${with_cligen}"
-  CPPFLAGS="-I${with_cligen}/include ${CPPFLAGS}"
-  LDFLAGS="-L${with_cligen}/lib ${LDFLAGS}"
-  test -d "$with_cligen" && CLIGEN_PREFIX="$with_cligen"
+    echo "Using CLIGEN here: ${CLIGEN_DIR}"
+    CPPFLAGS="-I${CLIGEN_DIR}$(eval echo ${includedir}) ${CPPFLAGS}"
+    LDFLAGS="-L${CLIGEN_DIR}$(eval echo ${libdir}) ${LDFLAGS}"
 fi
 
 # Disable/enable yang patch

--- a/configure.ac
+++ b/configure.ac
@@ -169,6 +169,10 @@ if test "$prefix" = "NONE"; then
      prefix=${ac_default_prefix}
 fi
 
+if test "$exec_prefix" = "NONE"; then
+     exec_prefix=${prefix}
+fi
+
 # Postfix for shared libs 
 SH_SUFFIX=".so"
 # Postfix for static libs 
@@ -405,7 +409,6 @@ AH_BOTTOM([#include <clixon_custom.h>])
 # Expand for easy replacement in example/main/example.xml.in
 # Special case is $libdir, which is composed from $exec_prefix
 test "x$prefix" = xNONE && prefix=$ac_default_prefix
-test "x$exec_prefix" = xNONE && exec_prefix='${prefix}'
 SYSCONFDIR=`eval echo $sysconfdir`
 LIBDIR=`eval echo $libdir`
 LIBDIR=`eval echo $LIBDIR`

--- a/configure.ac
+++ b/configure.ac
@@ -71,13 +71,6 @@ else
    : ${CFLAGS="-O2 -Wall"}
 fi
 
-# Check CLIgen
-if test "$prefix" = "NONE"; then
-	CLIGEN_PREFIX="$ac_default_prefix"
-else
-	CLIGEN_PREFIX="$prefix"
-fi
-
 AC_CONFIG_HEADERS([include/clixon_config.h lib/clixon/clixon.h])
 
 AC_DEFINE_UNQUOTED(CLIXON_VERSION_STRING, $CLIXON_VERSION, [Clixon version string])
@@ -96,7 +89,6 @@ AC_SUBST(CLIXON_VERSION)
 AC_SUBST(CLIXON_VERSION_STRING)
 AC_SUBST(CLIXON_VERSION_MAJOR)
 AC_SUBST(CLIXON_VERSION_MINOR)
-AC_SUBST(CLIGEN_PREFIX)
 
 AC_MSG_RESULT(CLIXON version is ${CLIXON_VERSION})
 

--- a/configure.ac
+++ b/configure.ac
@@ -411,7 +411,6 @@ AH_BOTTOM([#include <clixon_custom.h>])
 test "x$prefix" = xNONE && prefix=$ac_default_prefix
 SYSCONFDIR=`eval echo $sysconfdir`
 LIBDIR=`eval echo $libdir`
-LIBDIR=`eval echo $LIBDIR`
 LOCALSTATEDIR=`eval echo $localstatedir`
 
 AC_CONFIG_FILES([Makefile

--- a/docker/example/Dockerfile
+++ b/docker/example/Dockerfile
@@ -42,9 +42,8 @@ RUN apk add --update git make build-base gcc flex bison curl-dev
 RUN apk add --update nghttp2
 
 # Create a directory to hold source-code, dependencies etc
-RUN mkdir /clixon
+RUN mkdir -p /clixon/build
 
-RUN mkdir /clixon/build
 WORKDIR /clixon
 
 # Clone cligen
@@ -52,34 +51,34 @@ RUN git clone https://github.com/clicon/cligen.git
 
 # Build cligen
 WORKDIR /clixon/cligen
-RUN ./configure --prefix=/clixon/build
+RUN ./configure --prefix=/usr/local
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 
 # Need to add www user manually
 RUN adduser -D -H -G www-data www-data
 
 # Copy Clixon from local dir
-RUN mkdir /clixon/clixon
+RUN mkdir -p /clixon/clixon
 WORKDIR /clixon/clixon
 COPY clixon .
 
 # Configure, build and install clixon
-RUN ./configure --prefix=/clixon/build --with-cligen=/clixon/build --with-restconf=native --enable-nghttp2 --enable-http1
+RUN ./configure --prefix=/usr/local --with-cligen=/clixon/build --with-restconf=native --enable-nghttp2 --enable-http1
 
 RUN make
-RUN make install
-RUN make install-include
+RUN make DESTDIR=/clixon/build install
+RUN make DESTDIR=/clixon/build install-include
 
 # Install main example
 WORKDIR /clixon/clixon/example/main
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 
 # Copy startscript
 WORKDIR /clixon
 COPY startsystem.sh startsystem.sh 
-RUN install startsystem.sh /clixon/build/bin/
+RUN install startsystem.sh /clixon/build/usr/local/bin/
 
 #
 # Stage 2
@@ -109,7 +108,7 @@ RUN echo "Subsystem netconf /usr/local/bin/clixon_netconf" >> /etc/ssh/sshd_conf
 # Create clicon user and group
 RUN adduser -D -H clicon
 
-COPY --from=0 /clixon/build/ /usr/local/
+COPY --from=0 /clixon/build/ /
 
 # Overwrite config file since install dirs are wrong
 COPY example.xml /usr/local/etc/example.xml

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -42,10 +42,8 @@ RUN apk add --update git make build-base gcc flex bison curl-dev
 # For netsnmp
 RUN apk add --update net-snmp net-snmp-dev
 
-WORKDIR /usr/local/share
-
 # Checkout standard YANG models for tests (note >1G for full repo)
-RUN mkdir yang
+RUN mkdir -p /usr/local/share/yang
 
 WORKDIR /usr/local/share/yang
 
@@ -56,12 +54,10 @@ RUN git config core.sparseCheckout true
 RUN echo "standard/" >> .git/info/sparse-checkout
 RUN echo "experimental/" >> .git/info/sparse-checkout
 
-WORKDIR /usr/local/share/yang
 RUN git pull origin main
 
 # Create a directory to hold source-code, dependencies etc
-RUN mkdir /clixon
-RUN mkdir /clixon/build
+RUN mkdir -p /clixon/build
 WORKDIR /clixon
 
 # Clone cligen
@@ -69,9 +65,9 @@ RUN git clone https://github.com/clicon/cligen.git
 
 # Build cligen
 WORKDIR /clixon/cligen
-RUN ./configure --prefix=/clixon/build
+RUN ./configure --prefix=/usr/local
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 
 # Copy Clixon from local dir
 RUN mkdir /clixon/clixon
@@ -79,29 +75,26 @@ WORKDIR /clixon/clixon
 COPY clixon .
 
 # Configure, build and install clixon
-RUN ./configure --prefix=/clixon/build --with-cligen=/clixon/build --without-restconf --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/
+RUN ./configure --prefix=/usr/local --with-cligen=/clixon/build --without-restconf --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 
 # Install utils (for tests)
 WORKDIR /clixon/clixon/util
 RUN make
-RUN make install
-
-RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 
 # Copy tests
 WORKDIR /clixon/clixon/test
-RUN install -d /clixon/build/bin/test
-RUN install *.sh /clixon/build/bin/test
-RUN install *.exp /clixon/build/bin/test
-RUN install clixon.png /clixon/build/bin/test
+RUN install -d /clixon/build/usr/local/bin/test
+RUN install *.sh /clixon/build/usr/local/bin/test
+RUN install *.exp /clixon/build/usr/local/bin/test
+RUN install clixon.png /clixon/build/usr/local/bin/test
 
 # Copy startscript
 WORKDIR /clixon
 COPY startsystem.sh startsystem.sh 
-RUN install startsystem.sh /clixon/build/bin/
+RUN install startsystem.sh /clixon/build/usr/local/bin/
 
 # Add our generated YANG files
 RUN git clone https://github.com/clicon/mib-yangs.git /usr/local/share/mib-yangs
@@ -131,7 +124,7 @@ RUN apk add --update sudo curl procps grep make bash expect
 # Create clicon user and group
 RUN adduser -D -H clicon
 
-COPY --from=0 /clixon/build/ /usr/local/
+COPY --from=0 /clixon/build/ /
 COPY --from=0 /usr/local/share/yang/ /usr/local/share/yang/
 COPY --from=0 /usr/local/share/mib-yangs/* /usr/local/share/mib-yangs/
 

--- a/docker/test/Dockerfile.native
+++ b/docker/test/Dockerfile.native
@@ -44,32 +44,28 @@ RUN apk add --update nghttp2
 # For netsnmp
 RUN apk add --update net-snmp net-snmp-dev
 
-# Checkut models
-WORKDIR /usr/local/share/
-
 # Checkout standard YANG models for tests (note >1G for full repo)
-RUN mkdir yang
+RUN mkdir -p /usr/local/share/yang
 
 WORKDIR /usr/local/share/yang
 
 RUN git config --global init.defaultBranch master
-RUN git init;
-RUN git remote add -f origin https://github.com/YangModels/yang;
+RUN git init
+RUN git remote add -f origin https://github.com/YangModels/yang
 RUN git config core.sparseCheckout true
 RUN echo "standard/" >> .git/info/sparse-checkout
 RUN echo "experimental/" >> .git/info/sparse-checkout
 
 RUN git pull origin main
 
-RUN mkdir /usr/local/share/openconfig
+RUN mkdir -p /usr/local/share/openconfig
 WORKDIR /usr/local/share/openconfig
 
 # Checkut Openconfig models for tests
 RUN git clone https://github.com/openconfig/public
 
 # Create a directory to hold source-code, dependencies etc
-RUN mkdir /clixon
-RUN mkdir /clixon/build
+RUN mkdir -p /clixon/build
 WORKDIR /clixon
 
 # Clone cligen
@@ -77,41 +73,42 @@ RUN git clone https://github.com/clicon/cligen.git
 
 # Build cligen
 WORKDIR /clixon/cligen
-RUN ./configure --prefix=/clixon/build
+RUN ./configure --prefix=/usr/local --sysconfdir=/etc
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 
 # Need to add www user manually
 RUN adduser -D -H -G www-data www-data
 
 # Copy Clixon from local dir
-RUN mkdir /clixon/clixon
+RUN mkdir -p /clixon/clixon
 WORKDIR /clixon/clixon
 COPY clixon .
 
 # Configure, build and install clixon
-RUN ./configure --prefix=/clixon/build --with-cligen=/clixon/build --with-restconf=native --enable-nghttp2 --enable-http1 --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/
+RUN ./configure --prefix=/usr/local --sysconfdir=/etc --with-cligen=/clixon/build --with-restconf=native --enable-nghttp2 --enable-http1 --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/
 
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 
 # Install utils (for tests)
 WORKDIR /clixon/clixon/util
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 
 # Build and install the clixon example
 WORKDIR /clixon/clixon/example/main
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
+RUN mkdir -p /clixon/build/etc
 RUN install example.xml /clixon/build/etc/clixon.xml
 
 # Copy tests
 WORKDIR /clixon/clixon/test
-RUN install -d /clixon/build/bin/test
-RUN install *.sh /clixon/build/bin/test
-RUN install *.exp /clixon/build/bin/test
-RUN install clixon.png /clixon/build/bin/test
+RUN install -d /clixon/build/usr/local/bin/test
+RUN install *.sh /clixon/build/usr/local/bin/test
+RUN install *.exp /clixon/build/usr/local/bin/test
+RUN install clixon.png /clixon/build/usr/local/bin/test
 
 RUN install -d /clixon/build/mibs
 RUN install mibs/* /clixon/build/mibs
@@ -119,7 +116,7 @@ RUN install mibs/* /clixon/build/mibs
 # Copy startscript
 WORKDIR /clixon
 COPY startsystem_native.sh startsystem.sh 
-RUN install startsystem.sh /clixon/build/bin/
+RUN install startsystem.sh /clixon/build/usr/local/bin/
 
 # Add our generated YANG files
 RUN git clone https://github.com/clicon/mib-yangs.git /usr/local/share/mib-yangs
@@ -161,7 +158,7 @@ EXPOSE 443/tcp
 # Create clicon user and group
 RUN adduser -D -H clicon
 
-COPY --from=0 /clixon/build/ /usr/local/
+COPY --from=0 /clixon/build/ /
 COPY --from=0 /usr/local/share/yang/ /usr/local/share/yang/
 COPY --from=0 /usr/local/share/openconfig/* /usr/local/share/openconfig/
 COPY --from=0 /usr/local/share/mib-yangs/* /usr/local/share/mib-yangs/


### PR DESCRIPTION
The main purpose of these commits is to fix build when `CLIGEN_DIR` is set or `--with-cligen=dir` is passed to configure.  Before this change CFLAGS and LDFLAGS were not respecting `$includedir` and `$libdir`