### PR TITLE
Implement restconf netns default

### DIFF
--- a/configure
+++ b/configure
@@ -755,6 +755,7 @@ enable_debug
 with_cligen
 enable_yang_patch
 enable_publish
+with_restconf_netns
 with_restconf
 enable_http1
 enable_nghttp2
@@ -1417,6 +1418,9 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-cligen=dir       Use CLIGEN installation in this dir
+  --with-restconf-netns=NAMESPACE
+                          Define default restconf network namespace to
+                          NAMESPACE
   --with-restconf=native  Integration with embedded web server (DEFAULT)
   --with-restconf=fcgi    FCGI interface for stand-alone web rev-proxy eg
                           nginx
@@ -6110,6 +6114,24 @@ then :
 else $as_nop
   as_fn_error $? "CLIgen missing. Try: git clone https://github.com/clicon/cligen.git" "$LINENO" 5
 fi
+
+
+
+# Check whether --with-restconf-netns was given.
+if test ${with_restconf_netns+y}
+then :
+  withval=$with_restconf_netns; restconf_netns="$withval"
+else $as_nop
+  restconf_netns="default"
+fi
+
+
+if test -z "$restconf_netns"; then
+   as_fn_error $? "restconf-netns cannot be empty" "$LINENO" 5
+fi
+
+
+printf "%s\n" "#define RESTCONF_NETNS_DEFAULT \"$restconf_netns\"" >>confdefs.h
 
 
 # This is for restconf.  There are three options:

--- a/configure.ac
+++ b/configure.ac
@@ -231,6 +231,17 @@ AC_CHECK_HEADERS(cligen/cligen.h,, AC_MSG_ERROR([CLIgen missing. Try: git clone 
 
 AC_CHECK_LIB(cligen, cligen_init,, AC_MSG_ERROR([CLIgen missing. Try: git clone https://github.com/clicon/cligen.git]))
 
+AC_ARG_WITH([restconf-netns],
+	AS_HELP_STRING([--with-restconf-netns=NAMESPACE],[Define default restconf network namespace to NAMESPACE]),
+	[restconf_netns="$withval"],
+	[restconf_netns="default"])
+
+if test -z "$restconf_netns"; then
+   AC_MSG_ERROR([restconf-netns cannot be empty])
+fi
+
+AC_DEFINE_UNQUOTED([RESTCONF_NETNS_DEFAULT], "$restconf_netns", [Default restconf network namespace])
+
 # This is for restconf.  There are three options:
 # --without-restconf     No restconf support
 # --with-restconf=fcgi   FCGI interface for separate web reverse proxy like nginx

--- a/include/clixon_config.h.in
+++ b/include/clixon_config.h.in
@@ -156,6 +156,9 @@
 /* Define to the version of this package. */
 #undef PACKAGE_VERSION
 
+/* Default restconf network namespace */
+#undef RESTCONF_NETNS_DEFAULT
+
 /* SSH binary */
 #undef SSH_BIN
 

--- a/include/clixon_custom.h
+++ b/include/clixon_custom.h
@@ -93,14 +93,6 @@
  */
 #define DATASTORE_TOP_SYMBOL "config"
 
-/*! Name of default netns for clixon-restconf.yang socket/namespace field
- * Restconf allows opening sockets in different network namespaces. This is teh name of 
- * "host"/"default" namespace. Unsure what to really label this but seems like there is differing
- * consensus on how to label it.
- * Either find that proper label, or move it to a option
- */
-#define RESTCONF_NETNS_DEFAULT "default"
-
 /*! If set make an internal redirect if URI path indetifies a directory
  * For example, path is /local, and redirect is 'index.html, the request 
  * will be redirected to /local/index.html


### PR DESCRIPTION
This PR branch is based on PR #436 and cannot be merged before it.

The idea is to make it possible to change default restconf network namespace as a configure option.  Only 3 last commits belong to this one.