### PR TITLE
Avoid copying timeval onto stack

### DIFF
--- a/apps/backend/backend_client.c
+++ b/apps/backend/backend_client.c
@@ -215,7 +215,7 @@ backend_monitoring_state_get(clicon_handle h,
         if (ce->ce_source_host)
             cprintf(cb, "<source-host>%s</source-host>", ce->ce_source_host);
         if (ce->ce_time.tv_sec != 0){
-            if (time2str(ce->ce_time, timestr, sizeof(timestr)) < 0){
+            if (time2str(&ce->ce_time, timestr, sizeof(timestr)) < 0){
                 clicon_err(OE_UNIX, errno, "time2str");
                 goto done;
             }

--- a/lib/src/clixon_netconf_monitoring.c
+++ b/lib/src/clixon_netconf_monitoring.c
@@ -74,7 +74,7 @@ per_datastore(clicon_handle h,
 {
     int            retval = -1;
     uint32_t       sid;
-    struct timeval tv = {0,};
+    struct timeval tv;
     char           timestr[28];
 
     cprintf(cb, "<datastore><name>%s</name>", db);
@@ -83,7 +83,7 @@ per_datastore(clicon_handle h,
         cprintf(cb, "<global-lock>");
         cprintf(cb, "<locked-by-session>%u</locked-by-session>", sid);
         xmldb_lock_timestamp(h, db, &tv);
-        if (time2str(tv, timestr, sizeof(timestr)) < 0){
+        if (time2str(&tv, timestr, sizeof(timestr)) < 0){
             clicon_err(OE_UNIX, errno, "time2str");
             goto done;
         }
@@ -321,7 +321,7 @@ netconf_monitoring_statistics_init(clicon_handle h)
     cvec          *cvv = NULL;
 
     gettimeofday(&tv, NULL);
-    if (time2str(tv, timestr, sizeof(timestr)) < 0)
+    if (time2str(&tv, timestr, sizeof(timestr)) < 0)
         goto done;
     clicon_data_set(h, "netconf-start-time", timestr); /* RFC 6022 */
     if ((cvv = cvec_new(0)) == NULL){

--- a/lib/src/clixon_proc.c
+++ b/lib/src/clixon_proc.c
@@ -753,7 +753,7 @@ clixon_process_status(clicon_handle  h,
                 cprintf(cbret, "<status xmlns=\"%s\">%s</status>", CLIXON_LIB_NS,
                         clicon_int2str(proc_state_map, pe->pe_state));
                 if (timerisset(&pe->pe_starttime)){
-                    if (time2str(pe->pe_starttime, timestr, sizeof(timestr)) < 0){
+                    if (time2str(&pe->pe_starttime, timestr, sizeof(timestr)) < 0){
                         clicon_err(OE_UNIX, errno, "time2str");
                         goto done;
                     }

--- a/lib/src/clixon_stream.c
+++ b/lib/src/clixon_stream.c
@@ -580,7 +580,7 @@ stream_notify(clicon_handle h,
         goto done;
     }
     gettimeofday(&tv, NULL);
-    if (time2str(tv, timestr, sizeof(timestr)) < 0){
+    if (time2str(&tv, timestr, sizeof(timestr)) < 0){
         clicon_err(OE_UNIX, errno, "time2str");
         goto done;
     }
@@ -645,7 +645,7 @@ stream_notify_xml(clicon_handle h,
         goto done;
     }
     gettimeofday(&tv, NULL);
-    if (time2str(tv, timestr, sizeof(timestr)) < 0){
+    if (time2str(&tv, timestr, sizeof(timestr)) < 0){
         clicon_err(OE_UNIX, errno, "time2str");
         goto done;
     }

--- a/util/clixon_util_stream.c
+++ b/util/clixon_util_stream.c
@@ -241,10 +241,9 @@ main(int argc, char **argv)
             break;
         case 's': /* start-time */
             if (*optarg == '+' || *optarg == '-'){
-                struct timeval t;
-                t = now;
+                struct timeval t = now;
                 t.tv_sec += atoi(optarg);
-                if (time2str(t, start, sizeof(start)) < 0)
+                if (time2str(&t, start, sizeof(start)) < 0)
                     goto done;
             }
             else
@@ -252,10 +251,9 @@ main(int argc, char **argv)
             break;
         case 'e': /* stop-time */
             if (*optarg == '+' || *optarg == '-'){
-                struct timeval t;
-                t = now;
+                struct timeval t = now;
                 t.tv_sec += atoi(optarg);
-                if (time2str(t, stop, sizeof(stop)) < 0)
+                if (time2str(&t, stop, sizeof(stop)) < 0)
                     goto done;
             }
             else


### PR DESCRIPTION
Even though a `struct timeval` isn't a particularly large structure, it's a bad practice to pass structures by value as it's inefficient.
