### PR TITLE
Make error output consistently sent to same destination

### DIFF
--- a/apps/backend/backend_main.c
+++ b/apps/backend/backend_main.c
@@ -1029,13 +1029,13 @@ main(int    argc,
        daemonized errors OK. Before this stage, errors are logged on stderr 
        also */
     if (foreground==0){
+        clicon_log_init(__PROGRAM__, dbg?LOG_DEBUG:LOG_INFO,
+                        logdst==CLICON_LOG_FILE?CLICON_LOG_FILE:CLICON_LOG_SYSLOG);
         /* Call plugin callbacks just before fork/daemonization */
         if (clixon_plugin_pre_daemon_all(h) < 0)
             goto done;
-        clicon_log_init(__PROGRAM__, dbg?LOG_DEBUG:LOG_INFO,
-                        logdst==CLICON_LOG_FILE?CLICON_LOG_FILE:CLICON_LOG_SYSLOG);
         if (daemon(0, 0) < 0){
-            fprintf(stderr, "config: daemon");
+            clicon_err(OE_UNIX, errno, "daemon");
             exit(-1);
         }
     }

--- a/apps/restconf/restconf_main_native.c
+++ b/apps/restconf/restconf_main_native.c
@@ -669,7 +669,7 @@ restconf_clixon_backend(clicon_handle h,
     while (1){
         if (clicon_hello_req(h, "cl:restconf", NULL, &id) < 0){
             if (errno == ENOENT){
-                fprintf(stderr, "waiting");
+                clicon_err(OE_UNIX, errno, "waiting");
                 sleep(1);
                 continue;
             }

--- a/lib/src/clixon_proc.c
+++ b/lib/src/clixon_proc.c
@@ -214,18 +214,18 @@ clixon_proc_socket(char **argv,
         close(sp[0]);
         close(0);
         if (dup2(sp[1], STDIN_FILENO) < 0){
-            perror("dup2");
+            clicon_err(OE_UNIX, errno, "dup2(STDIN)");
             return -1;
         }
         close(1);
         if (dup2(sp[1], STDOUT_FILENO) < 0){
-            perror("dup2");
+            clicon_err(OE_UNIX, errno, "dup2(STDOUT)");
             return -1;
         }
         close(sp[1]); 
         
         if (execvp(argv[0], argv) < 0){
-            perror("execvp");
+            clicon_err(OE_UNIX, errno, "execvp '%s'", argv[0]);
             return -1;
         }
         exit(-1);        /* Shouldnt reach here */

--- a/lib/src/clixon_uid.c
+++ b/lib/src/clixon_uid.c
@@ -173,6 +173,8 @@ drop_priv_temp(uid_t new_uid)
 #ifdef HAVE_GETRESUID
     int retval = -1;
     
+    clicon_debug(4, "%s uid:%u", __FUNCTION__, new_uid);
+
     /* XXX: implicit declaration of function 'setresuid' on travis */
     if (setresuid(-1, new_uid, geteuid()) < 0){
         clicon_err(OE_UNIX, errno, "setresuid");
@@ -202,6 +204,8 @@ drop_priv_perm(uid_t new_uid)
     uid_t ruid;
     uid_t euid;
     uid_t suid;
+
+    clicon_debug(4, "%s uid:%u", __FUNCTION__, new_uid);
 
     if (setresuid(new_uid, new_uid, new_uid) < 0){
         clicon_err(OE_UNIX, errno, "setresuid");
@@ -236,6 +240,8 @@ restore_priv(void)
     uid_t euid;
     uid_t suid;
     
+    clicon_debug(4, "%s", __FUNCTION__);
+
     if (getresuid(&ruid, &euid, &suid) < 0){
         clicon_err(OE_UNIX, errno, "setresuid");
         goto done;

--- a/util/Makefile.in
+++ b/util/Makefile.in
@@ -164,6 +164,12 @@ clixon_util_validate: clixon_util_validate.c $(BELIBDEPS) $(LIBDEPS)
 clixon_util_dispatcher: clixon_util_dispatcher.c $(BELIBDEPS) $(LIBDEPS)
 	$(CC) $(INCLUDES) $(CPPFLAGS) -D__PROGRAM__=\"$@\" $(CFLAGS) $(LDFLAGS) $^ -l clixon_backend -o $@ $(LIBS) $(BELIBS)
 
+clixon_netconf_ssh_callhome: clixon_netconf_ssh_callhome.c $(LIBDEPS)
+	$(CC) $(INCLUDES) $(CPPFLAGS) -D__PROGRAM__=\"$@\" $(CFLAGS) $(LDFLAGS) $^ $(LIBS) -o $@
+
+clixon_netconf_ssh_callhome_client: clixon_netconf_ssh_callhome_client.c $(LIBDEPS)
+	$(CC) $(INCLUDES) $(CPPFLAGS) -D__PROGRAM__=\"$@\" $(CFLAGS) $(LDFLAGS) $^ $(LIBS) -o $@
+
 ifdef with_restconf
 clixon_util_stream: clixon_util_stream.c $(LIBDEPS)
 	$(CC) $(INCLUDES) $(CPPFLAGS) -D__PROGRAM__=\"$@\" $(CFLAGS) $(LDFLAGS) $^ $(LIBS) -lcurl -o $@

--- a/util/clixon_util_path.c
+++ b/util/clixon_util_path.c
@@ -186,14 +186,14 @@ main(int    argc,
         /* First read api-path from file */
         len = 1024; /* any number is fine */
         if ((buf = malloc(len)) == NULL){
-            perror("pt_file malloc");
+            clicon_err(OE_UNIX, errno, "malloc");
             return -1;
         }
         memset(buf, 0, len);
         i = 0;
         while (1){ 
             if ((ret = read(0, &c, 1)) < 0){
-                perror("read");
+                clicon_err(OE_UNIX, errno, "read");
                 goto done;
             }
             if (ret == 0)
@@ -202,7 +202,7 @@ main(int    argc,
                 break;
             if (len==i){
                 if ((buf = realloc(buf, 2*len)) == NULL){
-                    fprintf(stderr, "%s: realloc: %s\n", __FUNCTION__, strerror(errno));
+                    clicon_err(OE_UNIX, errno, "realloc");
                     return -1;
                 }           
                 memset(buf+len, 0, len);
@@ -218,7 +218,7 @@ main(int    argc,
      * XXX Note 0 above, stdin here
      */
     if (clixon_xml_parse_file(fp, YB_NONE, NULL, &x, NULL) < 0){
-        fprintf(stderr, "Error: parsing: %s\n", clicon_err_reason);
+        clicon_err(OE_XML, 0, "Error parsing: %s", clicon_err_reason);
         return -1;
     }
 
@@ -228,13 +228,13 @@ main(int    argc,
         if ((ret = xml_bind_yang(h, x, YB_MODULE, yspec, &xerr)) < 0)
             goto done;
         if (ret == 0){
-            if ((cb = cbuf_new()) ==NULL){
+            if ((cb = cbuf_new()) == NULL){
                 clicon_err(OE_XML, errno, "cbuf_new");
                 goto done;
             }
             if (netconf_err2cb(xerr, cb) < 0)
                 goto done;
-            fprintf(stderr, "xml validation error: %s\n", cbuf_get(cb));
+            clicon_err(OE_XML, 0, "xml validation error: %s", cbuf_get(cb));
             goto done;
         }
         /* sort */
@@ -256,7 +256,7 @@ main(int    argc,
             }
             if (netconf_err2cb(xerr, cb) < 0)
                 goto done;
-            fprintf(stderr, "xml validation error: %s\n", cbuf_get(cb));
+            clicon_err(OE_XML, 0, "xml validation error: %s", cbuf_get(cb));
             goto done;
         }
 
@@ -273,7 +273,7 @@ main(int    argc,
                 goto done;
         }
         if (ret == 0){
-            fprintf(stderr, "Fail %d %s\n", clicon_errno, clicon_err_reason);
+            clicon_err(OE_XML, clicon_errno, "Failed: %s", clicon_err_reason);
             goto done;
         }
     }
@@ -282,7 +282,7 @@ main(int    argc,
         xc = xvec[i];
         fprintf(stdout, "%d: ", i);
         clixon_xml2file(stdout, xc, 0, 0, NULL, fprintf, 0, 0);
-        fprintf(stdout, "\n");
+        fputc('\n', stdout);
         fflush(stdout);
     }
     retval = 0;


### PR DESCRIPTION
_In progress_

Drop `perror()` and `fprintf()`, otherwise messages won't be seen if service is started from `systemd` or `procd`.