### PR TITLE
Cleanup error handling

### DIFF
--- a/apps/backend/backend_main.c
+++ b/apps/backend/backend_main.c
@@ -1029,13 +1029,13 @@ main(int    argc,
        daemonized errors OK. Before this stage, errors are logged on stderr 
        also */
     if (foreground==0){
+        clicon_log_init(__PROGRAM__, dbg?LOG_DEBUG:LOG_INFO,
+                        logdst==CLICON_LOG_FILE?CLICON_LOG_FILE:CLICON_LOG_SYSLOG);
         /* Call plugin callbacks just before fork/daemonization */
         if (clixon_plugin_pre_daemon_all(h) < 0)
             goto done;
-        clicon_log_init(__PROGRAM__, dbg?LOG_DEBUG:LOG_INFO,
-                        logdst==CLICON_LOG_FILE?CLICON_LOG_FILE:CLICON_LOG_SYSLOG);
         if (daemon(0, 0) < 0){
-            fprintf(stderr, "config: daemon");
+            clicon_err(OE_UNIX, errno, "daemon");
             exit(-1);
         }
     }

--- a/apps/restconf/restconf_main_native.c
+++ b/apps/restconf/restconf_main_native.c
@@ -669,7 +669,7 @@ restconf_clixon_backend(clicon_handle h,
     while (1){
         if (clicon_hello_req(h, "cl:restconf", NULL, &id) < 0){
             if (errno == ENOENT){
-                fprintf(stderr, "waiting");
+                clicon_err(OE_UNIX, errno, "waiting");
                 sleep(1);
                 continue;
             }

--- a/apps/restconf/restconf_main_native.c
+++ b/apps/restconf/restconf_main_native.c
@@ -301,23 +301,10 @@ restconf_verify_certs(int             preverify_ok,
 static int
 alpn_proto_dump(const char *label,
                 const char *inp,
-                int         len)
+                unsigned    len)
 {
-
-    int   retval = -1;
-    char *str = NULL;
-    
-    if ((str = malloc(len+1)) == NULL){
-        clicon_err(OE_UNIX, errno, "malloc");
-        goto done;
-    }
-    strncpy(str, inp, len);
-    str[len] = '\0';
-    clicon_debug(1, "%s %s", label, str);
-    retval = 0;
- done:
-    free(str);
-    return retval;
+    clicon_debug(1, "%s %.*s", label, (int)len, inp);
+    return 0;
 }
 
 /*! Application-layer Protocol Negotiation (alpn) callback
@@ -533,7 +520,6 @@ restconf_checkcert_file(cxobj      *xrestconf,
 static int
 restconf_accept_client(int   fd,
                        void *arg)
-
 {
     int                     retval = -1;
     restconf_socket        *rsock;
@@ -1315,7 +1301,7 @@ main(int    argc,
     if ((ret = restconf_clixon_init(h, inline_config, &xrestconf)) < 0)
         goto done;
     if (ret == 0){ /* restconf disabled */
-        clicon_debug(1, "restconf configuration not found or disabled");
+        clicon_log(LOG_INFO, "restconf configuration not found or disabled");
         retval = 0;
         goto done;
     }

--- a/lib/src/clixon_plugin.c
+++ b/lib/src/clixon_plugin.c
@@ -374,8 +374,7 @@ plugin_load_one(clicon_handle     h,
     if ((p=strrchr(name, '.')) != NULL)
         *p = '\0';
     /* Copy name to struct */
-    snprintf(cp->cp_name, sizeof(cp->cp_name), "%*s",
-             (int)strlen(name), name);
+    snprintf(cp->cp_name, sizeof(cp->cp_name), "%s", name);
     cp->cp_api = *api;
     if (cp){
         *cpp = cp;
@@ -481,7 +480,7 @@ clixon_pseudo_plugin(clicon_handle     h,
         goto done;
     }
     memset(cp, 0, sizeof(struct clixon_plugin));
-    snprintf(cp->cp_name, sizeof(cp->cp_name), "%*s", (int)strlen(name), name);
+    snprintf(cp->cp_name, sizeof(cp->cp_name), "%s", name);
     ADDQ(cp, ms->ms_plugin_list);
     *cpp = cp;
     cp = NULL;

--- a/lib/src/clixon_string.c
+++ b/lib/src/clixon_string.c
@@ -178,12 +178,9 @@ clixon_string_del_join(char *str1,
         clicon_err(OE_UNIX, errno, "malloc");
         return NULL;
     }
-    if (str1){
-        snprintf(str, len, "%s%s%s", str1, del, str2);
+    snprintf(str, len, "%s%s%s", (str1 ? str1 : ""), del, str2);
+    if (str1)
         free(str1);
-    }
-    else
-        snprintf(str, len, "%s%s", del, str2);
     return str;
 }
 

--- a/lib/src/clixon_uid.c
+++ b/lib/src/clixon_uid.c
@@ -173,6 +173,8 @@ drop_priv_temp(uid_t new_uid)
 #ifdef HAVE_GETRESUID
     int retval = -1;
     
+    clicon_debug(CLIXON_DBG_DEFAULT, "%s uid:%u", __FUNCTION__, new_uid);
+
     /* XXX: implicit declaration of function 'setresuid' on travis */
     if (setresuid(-1, new_uid, geteuid()) < 0){
         clicon_err(OE_UNIX, errno, "setresuid");
@@ -186,7 +188,7 @@ drop_priv_temp(uid_t new_uid)
  done:
     return retval;
 #else
-    clicon_debug(1, "%s Drop privileges not implemented on this platform since getresuid is not available", __FUNCTION__);
+    clicon_debug(CLIXON_DBG_DEFAULT, "%s Drop privileges not implemented on this platform since getresuid is not available", __FUNCTION__);
     return 0;
 #endif
 }
@@ -202,6 +204,8 @@ drop_priv_perm(uid_t new_uid)
     uid_t ruid;
     uid_t euid;
     uid_t suid;
+
+    clicon_debug(CLIXON_DBG_DEFAULT, "%s uid:%u", __FUNCTION__, new_uid);
 
     if (setresuid(new_uid, new_uid, new_uid) < 0){
         clicon_err(OE_UNIX, errno, "setresuid");
@@ -221,7 +225,7 @@ drop_priv_perm(uid_t new_uid)
  done:
     return retval;
 #else
-    clicon_debug(1, "%s Drop privileges not implemented on this platform since getresuid is not available", __FUNCTION__);
+    clicon_debug(CLIXON_DBG_DEFAULT, "%s Drop privileges not implemented on this platform since getresuid is not available", __FUNCTION__);
     return 0;
 #endif
 }
@@ -235,7 +239,9 @@ restore_priv(void)
     uid_t ruid;
     uid_t euid;
     uid_t suid;
-    
+
+    clicon_debug(CLIXON_DBG_DEFAULT, "%s", __FUNCTION__);
+
     if (getresuid(&ruid, &euid, &suid) < 0){
         clicon_err(OE_UNIX, errno, "setresuid");
         goto done;
@@ -252,7 +258,7 @@ restore_priv(void)
  done:
     return retval;
 #else
-    clicon_debug(1, "%s Drop privileges not implemented on this platform since getresuid is not available", __FUNCTION__);
+    clicon_debug(CLIXON_DBG_DEFAULT, "%s Drop privileges not implemented on this platform since getresuid is not available", __FUNCTION__);
     return 0;
 #endif
 }

--- a/util/clixon_util_path.c
+++ b/util/clixon_util_path.c
@@ -282,7 +282,7 @@ main(int    argc,
         xc = xvec[i];
         fprintf(stdout, "%d: ", i);
         clixon_xml2file(stdout, xc, 0, 0, NULL, fprintf, 0, 0);
-        fprintf(stdout, "\n");
+        fputc('\n', stdout);
         fflush(stdout);
     }
     retval = 0;


### PR DESCRIPTION
There are calls to `fprintf(stderr, ...);` and `perror(...);` that only are seen if we're running in the foreground, with logging sent to `stdout`.