### PR TITLE
Avoid additional 'eval echo ...' sequences

### DIFF
--- a/configure
+++ b/configure
@@ -664,11 +664,14 @@ ac_ct_CXX
 CXXFLAGS
 CXX
 CPP
+SYSCONFDIR
+SBINDIR
 LOCALSTATEDIR
 LIBEXECDIR
 LIBDIR
+INCLUDEDIR
 DATADIR
-SYSCONFDIR
+BINDIR
 MIB_GENERATED_YANG_DIR
 YANG_STANDARD_DIR
 YANG_INSTALLDIR
@@ -4155,6 +4158,9 @@ HAVE_HTTP1=false
 
 
 
+
+
+
 #
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -5919,6 +5925,20 @@ SH_SUFFIX=".so"
 # Postfix for static libs
 LIBSTATIC_SUFFIX=".a"
 
+# Expand for easy replacement in example/main/example.xml.in
+# Special case is $libdir, which is composed from $exec_prefix
+BINDIR=`eval echo $bindir`
+SBINDIR=`eval echo $sbindir`
+SYSCONFDIR=`eval echo $sysconfdir`
+DATADIR=`eval echo \`eval echo $datadir\``
+INCLUDEDIR=`eval echo $includedir`
+LIBDIR=`eval echo \`eval echo $libdir\``
+LIBEXECDIR=`eval echo $libexecdir`
+LOCALSTATEDIR=`eval echo $localstatedir`
+
+CPPFLAGS="-I${INCLUDEDIR} ${CPPFLAGS}"
+LDFLAGS="-L${LIBDIR} ${LDFLAGS}"
+
 # This is for cligen
 
 # Check whether --with-cligen was given.
@@ -5932,8 +5952,8 @@ fi
 
 if test -n "${CLIGEN_DIR}" -a -d "${CLIGEN_DIR}"; then
     echo "Using CLIGEN here: ${CLIGEN_DIR}"
-    CPPFLAGS="-I${CLIGEN_DIR}$(eval echo ${includedir}) ${CPPFLAGS}"
-    LDFLAGS="-L${CLIGEN_DIR}$(eval echo ${libdir}) ${LDFLAGS}"
+    CPPFLAGS="-I${CLIGEN_DIR}${INCLUDEDIR} ${CPPFLAGS}"
+    LDFLAGS="-L${CLIGEN_DIR}${LIBDIR} ${LDFLAGS}"
 fi
 
 # Disable/enable yang patch
@@ -6929,14 +6949,7 @@ fi
 
 
 
-# Expand for easy replacement in example/main/example.xml.in
-# Special case is $libdir, which is composed from $exec_prefix
 test "x$prefix" = xNONE && prefix=$ac_default_prefix
-SYSCONFDIR=`eval echo $sysconfdir`
-DATADIR=`eval echo \`eval echo $datadir\``
-LIBDIR=`eval echo $libdir`
-LIBEXECDIR=`eval echo $libexecdir`
-LOCALSTATEDIR=`eval echo $localstatedir`
 
 ac_config_files="$ac_config_files Makefile lib/Makefile lib/src/Makefile lib/clixon/Makefile apps/Makefile apps/cli/Makefile apps/backend/Makefile apps/netconf/Makefile apps/restconf/Makefile apps/snmp/Makefile include/Makefile etc/Makefile etc/clixonrc example/Makefile example/main/Makefile example/main/example.xml docker/Makefile docker/clixon-dev/Makefile docker/example/Makefile docker/test/Makefile util/Makefile yang/Makefile yang/clixon/Makefile yang/mandatory/Makefile doc/Makefile test/Makefile test/config.sh test/cicd/Makefile test/vagrant/Makefile"
 

--- a/configure.ac
+++ b/configure.ac
@@ -122,11 +122,14 @@ AC_SUBST(YANG_STANDARD_DIR)
 # SNMP tests require generated YANGs from MIBs
 AC_SUBST(MIB_GENERATED_YANG_DIR)
 # Used in expansion in, e.g., example/main/example.xml.in
-AC_SUBST(SYSCONFDIR)
+AC_SUBST(BINDIR)
 AC_SUBST(DATADIR)
+AC_SUBST(INCLUDEDIR)
 AC_SUBST(LIBDIR)
 AC_SUBST(LIBEXECDIR)
 AC_SUBST(LOCALSTATEDIR)
+AC_SUBST(SBINDIR)
+AC_SUBST(SYSCONFDIR)
 
 #
 AC_PROG_CC()
@@ -180,8 +183,19 @@ SH_SUFFIX=".so"
 # Postfix for static libs 
 LIBSTATIC_SUFFIX=".a"
 
-CPPFLAGS="-I$(eval echo ${includedir}) ${CPPFLAGS}"
-LDFLAGS="-L$(eval echo ${libdir}) ${LDFLAGS}"
+# Expand for easy replacement in example/main/example.xml.in
+# Special case is $libdir, which is composed from $exec_prefix
+BINDIR=`eval echo $bindir`
+SBINDIR=`eval echo $sbindir`
+SYSCONFDIR=`eval echo $sysconfdir`
+DATADIR=`eval echo \`eval echo $datadir\``
+INCLUDEDIR=`eval echo $includedir`
+LIBDIR=`eval echo \`eval echo $libdir\``
+LIBEXECDIR=`eval echo $libexecdir`
+LOCALSTATEDIR=`eval echo $localstatedir`
+
+CPPFLAGS="-I${INCLUDEDIR} ${CPPFLAGS}"
+LDFLAGS="-L${LIBDIR} ${LDFLAGS}"
 
 # This is for cligen
 AC_ARG_WITH([cligen], [AS_HELP_STRING([--with-cligen=dir], [Use CLIGEN installation in this dir])], [
@@ -190,8 +204,8 @@ AC_ARG_WITH([cligen], [AS_HELP_STRING([--with-cligen=dir], [Use CLIGEN installat
 AC_SUBST(CLIGEN_DIR)
 if test -n "${CLIGEN_DIR}" -a -d "${CLIGEN_DIR}"; then
     echo "Using CLIGEN here: ${CLIGEN_DIR}"
-    CPPFLAGS="-I${CLIGEN_DIR}/include ${CPPFLAGS}"
-    LDFLAGS="-L${CLIGEN_DIR}/lib ${LDFLAGS}"
+    CPPFLAGS="-I${CLIGEN_DIR}${INCLUDEDIR} ${CPPFLAGS}"
+    LDFLAGS="-L${CLIGEN_DIR}${LIBDIR} ${LDFLAGS}"
 fi
 
 # Disable/enable yang patch
@@ -440,14 +454,7 @@ AC_ARG_ENABLE(nls)
 
 AH_BOTTOM([#include <clixon_custom.h>])
 
-# Expand for easy replacement in example/main/example.xml.in
-# Special case is $libdir, which is composed from $exec_prefix
 test "x$prefix" = xNONE && prefix=$ac_default_prefix
-SYSCONFDIR=`eval echo $sysconfdir`
-DATADIR=`eval echo \`eval echo $datadir\``
-LIBDIR=`eval echo $libdir`
-LIBEXECDIR=`eval echo $libexecdir`
-LOCALSTATEDIR=`eval echo $localstatedir`
 
 AC_CONFIG_FILES([Makefile
 	  lib/Makefile


### PR DESCRIPTION
Simplifying the previous "fix --with-cligen build option" so that we don't have to keep using `eval echo $var`.