### PR TITLE
Replace faulty solution to translate YANG union to SNMP

### DIFF
--- a/test/test_snmp_union.sh
+++ b/test/test_snmp_union.sh
@@ -82,7 +82,7 @@ cat <<EOF > $fstate
    <table xmlns="urn:example:clixon">
      <parameter>
        <Index>2</Index>
-       <Union_exm>4</Union_exm>
+       <Union_exm>2147483647</Union_exm>
      </parameter>
      <parameter>
        <Index>12</Index>


### PR DESCRIPTION
This PR replaces faulty solution to translate YANG union type to SNMP type:
 * Revert previous solution to translate YANG union into SNMP type that had memory leak due to cbuf allocation
 * Add simple mapping from YANG union to SNMP string