### PR TITLE
Revert PR#457 as it breaks cross-compilation

### DIFF
--- a/configure
+++ b/configure
@@ -5936,9 +5936,6 @@ LIBDIR=`eval echo \`eval echo $libdir\``
 LIBEXECDIR=`eval echo $libexecdir`
 LOCALSTATEDIR=`eval echo $localstatedir`
 
-CPPFLAGS="-I${INCLUDEDIR} ${CPPFLAGS}"
-LDFLAGS="-L${LIBDIR} ${LDFLAGS}"
-
 # This is for cligen
 
 # Check whether --with-cligen was given.
@@ -5952,8 +5949,8 @@ fi
 
 if test -n "${CLIGEN_DIR}" -a -d "${CLIGEN_DIR}"; then
     echo "Using CLIGEN here: ${CLIGEN_DIR}"
-    CPPFLAGS="-I${CLIGEN_DIR}${INCLUDEDIR} ${CPPFLAGS}"
-    LDFLAGS="-L${CLIGEN_DIR}${LIBDIR} ${LDFLAGS}"
+    CPPFLAGS="-I${CLIGEN_DIR}/include ${CPPFLAGS}"
+    LDFLAGS="-L${CLIGEN_DIR}/lib ${LDFLAGS}"
 fi
 
 # Disable/enable yang patch

--- a/configure.ac
+++ b/configure.ac
@@ -194,9 +194,6 @@ LIBDIR=`eval echo \`eval echo $libdir\``
 LIBEXECDIR=`eval echo $libexecdir`
 LOCALSTATEDIR=`eval echo $localstatedir`
 
-CPPFLAGS="-I${INCLUDEDIR} ${CPPFLAGS}"
-LDFLAGS="-L${LIBDIR} ${LDFLAGS}"
-
 # This is for cligen
 AC_ARG_WITH([cligen], [AS_HELP_STRING([--with-cligen=dir], [Use CLIGEN installation in this dir])], [
   CLIGEN_DIR="$withval"
@@ -204,8 +201,8 @@ AC_ARG_WITH([cligen], [AS_HELP_STRING([--with-cligen=dir], [Use CLIGEN installat
 AC_SUBST(CLIGEN_DIR)
 if test -n "${CLIGEN_DIR}" -a -d "${CLIGEN_DIR}"; then
     echo "Using CLIGEN here: ${CLIGEN_DIR}"
-    CPPFLAGS="-I${CLIGEN_DIR}${INCLUDEDIR} ${CPPFLAGS}"
-    LDFLAGS="-L${CLIGEN_DIR}${LIBDIR} ${LDFLAGS}"
+    CPPFLAGS="-I${CLIGEN_DIR}/include ${CPPFLAGS}"
+    LDFLAGS="-L${CLIGEN_DIR}/lib ${LDFLAGS}"
 fi
 
 # Disable/enable yang patch

--- a/docker/clixon-dev/Dockerfile
+++ b/docker/clixon-dev/Dockerfile
@@ -52,9 +52,9 @@ RUN git clone https://github.com/clicon/cligen.git
 
 # Build cligen
 WORKDIR /clixon/cligen
-RUN ./configure --prefix=/clixon/build
+RUN ./configure --prefix=/usr/local
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 
 # Need to add www user manually
 RUN adduser -D -H -G www-data www-data
@@ -65,8 +65,8 @@ WORKDIR /clixon/clixon
 COPY clixon .
 
 # Configure, build and install clixon
-RUN ./configure --prefix=/clixon/build --with-cligen=/clixon/build --with-restconf=native --enable-nghttp2 --enable-http1
+RUN ./configure --prefix=/usr/local --with-cligen=/clixon/build/usr/local --with-restconf=native --enable-nghttp2 --enable-http1
 
 RUN make
-RUN make install
+RUN make DESTDIR=/clixon/build install
 

--- a/docker/example/Dockerfile
+++ b/docker/example/Dockerfile
@@ -64,7 +64,7 @@ WORKDIR /clixon/clixon
 COPY clixon .
 
 # Configure, build and install clixon
-RUN ./configure --prefix=/usr/local --with-cligen=/clixon/build --with-restconf=native --enable-nghttp2 --enable-http1
+RUN ./configure --prefix=/usr/local --with-cligen=/clixon/build/usr/local --with-restconf=native --enable-nghttp2 --enable-http1
 
 RUN make
 RUN make DESTDIR=/clixon/build install

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -74,7 +74,7 @@ WORKDIR /clixon/clixon
 COPY clixon .
 
 # Configure, build and install clixon
-RUN ./configure --prefix=/usr/local --sysconfdir=/etc --with-cligen=/clixon/build --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/ -without-restconf
+RUN ./configure --prefix=/usr/local --sysconfdir=/etc --with-cligen=/clixon/build/usr/local --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/ -without-restconf
 RUN make
 RUN make DESTDIR=/clixon/build install
 

--- a/docker/test/Dockerfile.fcgi
+++ b/docker/test/Dockerfile.fcgi
@@ -82,7 +82,7 @@ RUN adduser -D -H -G www-data www-data
 RUN apk add --update nginx
 
 # Configure, build and install clixon
-RUN ./configure --prefix=/usr/local --sysconfdir=/etc --with-cligen=/clixon/build --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/ --with-restconf=fcgi 
+RUN ./configure --prefix=/usr/local --sysconfdir=/etc --with-cligen=/clixon/build/usr/include --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/ --with-restconf=fcgi
 RUN make
 RUN make DESTDIR=/clixon/build install
 

--- a/docker/test/Dockerfile.native
+++ b/docker/test/Dockerfile.native
@@ -79,7 +79,7 @@ WORKDIR /clixon/clixon
 COPY clixon .
 
 # Configure, build and install clixon
-RUN ./configure --prefix=/usr/local --sysconfdir=/etc --with-cligen=/clixon/build --with-restconf=native --enable-nghttp2 --enable-http1 --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/
+RUN ./configure --prefix=/usr/local --sysconfdir=/etc --with-cligen=/clixon/build/usr/local --with-restconf=native --enable-nghttp2 --enable-http1 --with-yang-standard-dir=/usr/local/share/yang/standard --enable-netsnmp --with-mib-generated-yang-dir=/usr/local/share/mib-yangs/
 
 RUN make
 RUN make DESTDIR=/clixon/build install


### PR DESCRIPTION
Adding `-I${INCLUDEDIR}` unconditionally to `CPPFLAGS` will cause the compiler to search the build-host's local headers, which will be disastrous.