### PR TITLE
Fix issues with valgrind w/ sudo

### DIFF
--- a/test/test_pagination_expect.exp
+++ b/test/test_pagination_expect.exp
@@ -24,7 +24,7 @@ set line2 [lindex $argv 3]
 
 set timeout 15
 
-spawn $clixon_cli -f $cfg
+spawn {*}$clixon_cli -f $cfg
 
 send "show pagination xpath $xpath cli\n"
 


### PR DESCRIPTION
Explode string into list of words for `spawn`.