### PR TITLE
Add more shades of debug messages

### DIFF
--- a/lib/clixon/clixon_debug.h
+++ b/lib/clixon/clixon_debug.h
@@ -62,6 +62,7 @@
 #define CLIXON_DBG_YANG		0x000010	/* YANG processing */
 #define CLIXON_DBG_CLIENT	0x000020	/* App-specific */
 #define CLIXON_DBG_NACM		0x000040	/* NACM processing */
+#define CLIXON_DBG_PROC		0x000080	/* Process handling */
 #define CLIXON_DBG_SMASK	0x00ffff	/* Subject mask */
 
 /*

--- a/lib/clixon/clixon_debug.h
+++ b/lib/clixon/clixon_debug.h
@@ -56,13 +56,14 @@
 
 /* Subject area */
 #define CLIXON_DBG_DEFAULT	0x000001	/* Default logs */
-#define CLIXON_DBG_MSG		0x000002	/* In/out messages and datastore reads */
+#define CLIXON_DBG_MSG		0x000002	/* In/out messages */
 #define CLIXON_DBG_XML		0x000004	/* XML processing */
 #define CLIXON_DBG_XPATH	0x000008	/* XPath processing */
 #define CLIXON_DBG_YANG		0x000010	/* YANG processing */
 #define CLIXON_DBG_CLIENT	0x000020	/* App-specific */
 #define CLIXON_DBG_NACM		0x000040	/* NACM processing */
 #define CLIXON_DBG_PROC		0x000080	/* Process handling */
+#define CLIXON_DBG_DATASTORE	0x000100	/* Datastore management */
 #define CLIXON_DBG_SMASK	0x00ffff	/* Subject mask */
 
 /*

--- a/lib/clixon/clixon_debug.h
+++ b/lib/clixon/clixon_debug.h
@@ -61,6 +61,7 @@
 #define CLIXON_DBG_XPATH	0x000008	/* XPath processing */
 #define CLIXON_DBG_YANG		0x000010	/* YANG processing */
 #define CLIXON_DBG_CLIENT	0x000020	/* App-specific */
+#define CLIXON_DBG_NACM		0x000040	/* NACM processing */
 #define CLIXON_DBG_SMASK	0x00ffff	/* Subject mask */
 
 /*

--- a/lib/clixon/clixon_debug.h
+++ b/lib/clixon/clixon_debug.h
@@ -64,6 +64,7 @@
 #define CLIXON_DBG_NACM		0x000040	/* NACM processing */
 #define CLIXON_DBG_PROC		0x000080	/* Process handling */
 #define CLIXON_DBG_DATASTORE	0x000100	/* Datastore management */
+#define CLIXON_DBG_EVENT	0x000200	/* Event processing */
 #define CLIXON_DBG_SMASK	0x00ffff	/* Subject mask */
 
 /*

--- a/lib/src/clixon_datastore.c
+++ b/lib/src/clixon_datastore.c
@@ -188,7 +188,7 @@ xmldb_copy(clixon_handle h,
     cxobj              *x1 = NULL;  /* from */
     cxobj              *x2 = NULL;  /* to */
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "%s %s", from, to);
+    clixon_debug(CLIXON_DBG_DATASTORE, "%s %s", from, to);
     /* XXX lock */
     if (clicon_datastore_cache(h) != DATASTORE_NOCACHE){
         /* Copy in-memory cache */
@@ -237,6 +237,7 @@ xmldb_copy(clixon_handle h,
         goto done;
     retval = 0;
  done:
+    clixon_debug(CLIXON_DBG_DATASTORE, "retval:%d", retval);
     if (fromfile)
         free(fromfile);
     if (tofile)
@@ -265,7 +266,7 @@ xmldb_lock(clixon_handle h,
     de0.de_id = id;
     gettimeofday(&de0.de_tv, NULL);
     clicon_db_elmnt_set(h, db, &de0);
-    clixon_debug(CLIXON_DBG_DEFAULT, "%s: locked by %u",  db, id);
+    clixon_debug(CLIXON_DBG_DATASTORE, "%s: locked by %u",  db, id);
     return 0;
 }
 
@@ -384,7 +385,7 @@ xmldb_exists(clixon_handle h,
     char               *filename = NULL;
     struct stat         sb;
 
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "%s", db);
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "%s", db);
     if (xmldb_db2file(h, db, &filename) < 0)
         goto done;
     if (lstat(filename, &sb) < 0)
@@ -397,6 +398,7 @@ xmldb_exists(clixon_handle h,
             retval = 1;
     }
  done:
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "retval:%d", retval);
     if (filename)
         free(filename);
     return retval;
@@ -442,7 +444,7 @@ xmldb_delete(clixon_handle h,
     char               *filename = NULL;
     struct stat         sb;
 
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "%s", db);
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "%s", db);
     if (xmldb_clear(h, db) < 0)
         goto done;
     if (xmldb_db2file(h, db, &filename) < 0)
@@ -454,6 +456,7 @@ xmldb_delete(clixon_handle h,
         }
     retval = 0;
  done:
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "retval:%d", retval);
     if (filename)
         free(filename);
     return retval;
@@ -476,7 +479,7 @@ xmldb_create(clixon_handle h,
     db_elmnt           *de = NULL;
     cxobj              *xt = NULL;
 
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "%s", db);
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "%s", db);
     if ((de = clicon_db_elmnt_get(h, db)) != NULL){
         if ((xt = de->de_xml) != NULL){
             xml_free(xt);
@@ -489,8 +492,9 @@ xmldb_create(clixon_handle h,
         clixon_err(OE_UNIX, errno, "open(%s)", filename);
         goto done;
     }
-   retval = 0;
+    retval = 0;
  done:
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "retval:%d", retval);
     if (filename)
         free(filename);
     if (fd != -1)

--- a/lib/src/clixon_datastore_read.c
+++ b/lib/src/clixon_datastore_read.c
@@ -550,7 +550,7 @@ xmldb_readfile(clixon_handle    h,
         clixon_err(OE_CFG, ENOENT, "No CLICON_XMLDB_FORMAT");
         goto done;
     }
-    clixon_debug(CLIXON_DBG_DEFAULT, "Reading datastore %s using %s", dbfile, format);
+    clixon_debug(CLIXON_DBG_DATASTORE, "Reading datastore %s using %s", dbfile, format);
     /* Parse file into internal XML tree from different formats */
     if ((fp = fopen(dbfile, "r")) == NULL) {
         clixon_err(OE_UNIX, errno, "open(%s)", dbfile);
@@ -859,14 +859,12 @@ xmldb_get_nocache(clixon_handle    h,
         if (disable_nacm_on_empty(xt, yspec) < 0)
             goto done;
     }
-    if (clixon_debug_isset(CLIXON_DBG_DEFAULT))
-        if (clixon_xml2file(stderr, xt, 0, 1, NULL, fprintf, 0, 0) < 0)
-            goto done;
+    clixon_debug_xml(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, xt, "");
     *xtop = xt;
     xt = NULL;
     retval = 1;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "retval:%d", retval);
     if (xt)
         xml_free(xt);
     if (xvec)
@@ -922,6 +920,8 @@ xmldb_get_cache(clixon_handle     h,
     cxobj     *x1t = NULL;
     db_elmnt   de0 = {0,};
     int        ret;
+
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "db %s", db);
 
     if ((yspec = clicon_dbspec_yang(h)) == NULL){
         clixon_err(OE_YANG, ENOENT, "No yang spec");
@@ -1054,11 +1054,11 @@ xmldb_get_cache(clixon_handle     h,
         if (disable_nacm_on_empty(x1t, yspec) < 0)
             goto done;
     }
-    clixon_debug_xml(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, x1t, "");
+    clixon_debug_xml(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, x1t, "");
     *xtop = x1t;
     retval = 1;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "retval:%d", retval);
     if (xvec)
         free(xvec);
     return retval;
@@ -1103,7 +1103,6 @@ xmldb_get_zerocopy(clixon_handle    h,
     cxobj         **xvec = NULL;
     size_t          xlen;
     int             i;
-    cxobj          *x0;
     db_elmnt       *de = NULL;
     db_elmnt        de0 = {0,};
     int             ret;
@@ -1138,7 +1137,7 @@ xmldb_get_zerocopy(clixon_handle    h,
      * For every node found in x0, mark the tree up to t1
      */
     for (i=0; i<xlen; i++){
-        x0 = xvec[i];
+        cxobj *x0 = xvec[i];
         xml_flag_set(x0, XML_FLAG_MARK);
         xml_apply_ancestor(x0, (xml_applyfn_t*)xml_flag_set, (void*)XML_FLAG_CHANGE);
     }
@@ -1203,13 +1202,11 @@ xmldb_get_zerocopy(clixon_handle    h,
         if (disable_nacm_on_empty(x0t, yspec) < 0)
             goto done;
     }
-    if (clixon_debug_isset(CLIXON_DBG_DEFAULT))
-        if (clixon_xml2file(stderr, x0t, 0, 1, NULL, fprintf, 0, 0) < 0)
-            goto done;
+    clixon_debug_xml(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, x0t, "");
     *xtop = x0t;
     retval = 1;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_DATASTORE | CLIXON_DBG_DETAIL, "retval:%d", retval);
     if (xvec)
         free(xvec);
     return retval;

--- a/lib/src/clixon_debug.c
+++ b/lib/src/clixon_debug.c
@@ -167,6 +167,7 @@ clixon_debug_fn(clixon_handle h,
         fprintf(stderr, "cbuf_new: %s\n", strerror(errno));
         goto done;
     }
+    cprintf(cb, "%s:%d: ", fn, line);
     va_start(ap, format);
     vcprintf(cb, format, ap);
     va_end(ap);    

--- a/lib/src/clixon_event.c
+++ b/lib/src/clixon_event.c
@@ -409,7 +409,7 @@ clixon_event_loop(clixon_handle h)
                  *     New select loop is called
                  * (3) Other signals result in an error and return -1.
                  */
-                clixon_debug(CLIXON_DBG_DEFAULT, "select: %s", strerror(errno));
+                clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "select: %s", strerror(errno));
                 if (clixon_exit_get() == 1){
                     clixon_err(OE_EVENTS, errno, "select");
                     retval = 0;
@@ -468,7 +468,7 @@ clixon_event_loop(clixon_handle h)
     }
     if (clixon_exit_get() == 1)
         retval = 0;
-    clixon_debug(CLIXON_DBG_DEFAULT, "done:%d", retval);
+    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d", retval);
     return retval;
 }
 

--- a/lib/src/clixon_event.c
+++ b/lib/src/clixon_event.c
@@ -199,7 +199,7 @@ clixon_event_reg_fd(int   fd,
     e->e_type = EVENT_FD;
     e->e_next = ee;
     ee = e;
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "registering %s", e->e_string);
+    clixon_debug(CLIXON_DBG_EVENT | CLIXON_DBG_DETAIL, "registering %s", e->e_string);
     return 0;
 }
 
@@ -293,7 +293,7 @@ clixon_event_reg_timeout(struct timeval t,
     }
     e->e_next = e1;
     *e_prev = e;
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "%s", str);
+    clixon_debug(CLIXON_DBG_EVENT | CLIXON_DBG_DETAIL, "%s", str);
     retval = 0;
  done:
     return retval;
@@ -409,7 +409,7 @@ clixon_event_loop(clixon_handle h)
                  *     New select loop is called
                  * (3) Other signals result in an error and return -1.
                  */
-                clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "select: %s", strerror(errno));
+                clixon_debug(CLIXON_DBG_EVENT | CLIXON_DBG_DETAIL, "select: %s", strerror(errno));
                 if (clixon_exit_get() == 1){
                     clixon_err(OE_EVENTS, errno, "select");
                     retval = 0;
@@ -435,7 +435,7 @@ clixon_event_loop(clixon_handle h)
         if (n==0){ /* Timeout */
             e = ee_timers;
             ee_timers = ee_timers->e_next;
-            clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "timeout: %s", e->e_string);
+            clixon_debug(CLIXON_DBG_EVENT | CLIXON_DBG_DETAIL, "timeout: %s", e->e_string);
             if ((*e->e_fn)(0, e->e_arg) < 0){
                 free(e);
                 goto err;
@@ -449,9 +449,9 @@ clixon_event_loop(clixon_handle h)
             }
             e_next = e->e_next;
             if(e->e_type == EVENT_FD && FD_ISSET(e->e_fd, &fdset)){
-                clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "FD_ISSET: %s", e->e_string);
+                clixon_debug(CLIXON_DBG_EVENT | CLIXON_DBG_DETAIL, "FD_ISSET: %s", e->e_string);
                 if ((*e->e_fn)(e->e_fd, e->e_arg) < 0){
-                    clixon_debug(CLIXON_DBG_DEFAULT, "Error in: %s", e->e_string);
+                    clixon_debug(CLIXON_DBG_EVENT, "Error in: %s", e->e_string);
                     goto err;
                 }
                 if (_ee_unreg){
@@ -463,12 +463,12 @@ clixon_event_loop(clixon_handle h)
         clixon_exit_decr(); /* If exit is set and > 1, decrement it (and exit when 1) */
         continue;
       err:
-        clixon_debug(CLIXON_DBG_DEFAULT, "err");
+        clixon_debug(CLIXON_DBG_EVENT, "err");
         break;
     }
     if (clixon_exit_get() == 1)
         retval = 0;
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_EVENT, "retval:%d", retval);
     return retval;
 }
 

--- a/lib/src/clixon_nacm.c
+++ b/lib/src/clixon_nacm.c
@@ -299,7 +299,7 @@ nacm_rpc(char         *rpc,
  permit:
     retval = 1;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d (0:deny 1:permit)", retval);
+    clixon_debug(CLIXON_DBG_NACM, "retval:%d (0:deny 1:permit)", retval);
     if (nsc)
         xml_nsctx_free(nsc);
     if (gvec)
@@ -770,7 +770,7 @@ nacm_datanode_write(clixon_handle    h,
  permit:
     retval = 1;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d (0:deny 1:permit)", retval);
+    clixon_debug(CLIXON_DBG_NACM, "retval:%d (0:deny 1:permit)", retval);
     if (pv_list)
         prepvec_free(pv_list);
     if (nsc)
@@ -1075,7 +1075,7 @@ nacm_datanode_read(clixon_handle h,
  ok:
     retval = 0;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_NACM, "retval:%d", retval);
     if (pv_list)
         prepvec_free(pv_list);
     if (nsc)
@@ -1128,7 +1128,7 @@ nacm_access_check(clixon_handle h,
     char  *wwwuser;
 #endif
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "");
+    clixon_debug(CLIXON_DBG_NACM, "");
     if ((nsc = xml_nsctx_init(NULL, NACM_NS)) == NULL)
         goto done;
     /* Do initial nacm processing common to all access validation in
@@ -1181,7 +1181,7 @@ nacm_access_check(clixon_handle h,
  done:
     if (nsc)
         xml_nsctx_free(nsc);
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d (0:deny 1:permit)", retval);
+    clixon_debug(CLIXON_DBG_NACM, "retval:%d (0:deny 1:permit)", retval);
     return retval;
  permit:
     retval = 1;

--- a/lib/src/clixon_proc.c
+++ b/lib/src/clixon_proc.c
@@ -218,6 +218,8 @@ clixon_proc_socket(clixon_handle h,
 	goto done;
     }
 
+    clixon_debug(CLIXON_DBG_PROC, "%s...", argv[0]);
+
     for (argc = 0; argv[argc] != NULL; ++argc)
          ;
     if ((flattened = clicon_strjoin(argc, argv, "', '")) == NULL){
@@ -263,7 +265,7 @@ clixon_proc_socket(clixon_handle h,
         exit(-1);        /* Shouldnt reach here */
     }
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "child %u sock %d", child, sp[0]);
+    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "child %u sock %d", child, sp[0]);
     /* Parent */
     close(sp[1]);
     *pid = child;
@@ -274,6 +276,7 @@ clixon_proc_socket(clixon_handle h,
         sigprocmask(SIG_SETMASK, &oset, NULL);
         set_signal(SIGINT, oldhandler, NULL);
     }
+    clixon_debug(CLIXON_DBG_PROC, "retval:%d", retval);
     return retval;
 }
 
@@ -288,7 +291,7 @@ clixon_proc_socket_close(pid_t pid,
     int retval = -1;
     int status;
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "pid %u sock %d", pid, sock);
+    clixon_debug(CLIXON_DBG_PROC, "pid %u sock %d", pid, sock);
 
     if (sock != -1)
         close(sock); /* usually kills */
@@ -296,8 +299,9 @@ clixon_proc_socket_close(pid_t pid,
     //    usleep(100000);     /* Wait for child to finish */
     if(waitpid(pid, &status, 0) == pid){
         retval = WEXITSTATUS(status);
-        clixon_debug(CLIXON_DBG_DEFAULT, "waitpid status %#x", retval);
+        clixon_debug(CLIXON_DBG_PROC, "waitpid status %#x", retval);
     }
+    clixon_debug(CLIXON_DBG_PROC, "retval:%d", retval);
     return retval;
 }
 
@@ -331,7 +335,7 @@ clixon_proc_background(clixon_handle h,
     char         *flattened;
     unsigned      argc;
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "");
+    clixon_debug(CLIXON_DBG_PROC, "");
     if (argv == NULL){
         clixon_err(OE_UNIX, EINVAL, "argv is NULL");
         goto quit;
@@ -368,7 +372,7 @@ clixon_proc_background(clixon_handle h,
         char nsfile[PATH_MAX];
         int  nsfd;
 #endif
-        clixon_debug(CLIXON_DBG_DEFAULT, "child");
+        clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "child");
         clicon_signal_unblock(0);
         signal(SIGTSTP, SIG_IGN);
         if (chdir("/") < 0){
@@ -388,7 +392,7 @@ clixon_proc_background(clixon_handle h,
          */
         if (netns != NULL) {
             snprintf(nsfile, PATH_MAX, "/var/run/netns/%s", netns); /* see man setns / ip netns */
-            clixon_debug(CLIXON_DBG_DEFAULT, "nsfile:%s", nsfile);
+            clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "nsfile:%s", nsfile);
             /* Change network namespace */
             if ((nsfd = open(nsfile, O_RDONLY | O_CLOEXEC)) < 0){
                 clixon_err(OE_UNIX, errno, "open");
@@ -427,7 +431,7 @@ clixon_proc_background(clixon_handle h,
     *pid0 = child;
     retval = 0;
  quit:
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d child:%u", retval, child);
+    clixon_debug(CLIXON_DBG_PROC, "retval:%d child:%u", retval, child);
     return retval;
 }
 
@@ -532,7 +536,7 @@ clixon_process_register(clixon_handle h,
         goto done;
     }
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "name:%s (%s)", name, argv[0]);
+    clixon_debug(CLIXON_DBG_PROC, "name:%s (%s)", name, argv[0]);
 
     if ((pe = malloc(sizeof(process_entry_t))) == NULL) {
         clixon_err(OE_DB, errno, "malloc");
@@ -572,7 +576,7 @@ clixon_process_register(clixon_handle h,
         }
     }
     pe->pe_callback = callback;
-    clixon_debug(CLIXON_DBG_DEFAULT, "%s ----> %s",
+    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "%s ----> %s",
                  pe->pe_name,
                  clicon_int2str(proc_state_map, PROC_STATE_STOPPED)
                  );
@@ -580,6 +584,7 @@ clixon_process_register(clixon_handle h,
     ADDQ(pe, _proc_entry_list);
     retval = 0;
  done:
+    clixon_debug(CLIXON_DBG_PROC, "retval:%d", retval);
     return retval;
 }
 
@@ -711,7 +716,7 @@ clixon_process_operation(clixon_handle  h,
     int              isrunning = 0;
     int              delay = 0;
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "name:%s op:%s", name, clicon_int2str(proc_operation_map, op0));
+    clixon_debug(CLIXON_DBG_PROC, "name:%s op:%s", name, clicon_int2str(proc_operation_map, op0));
     if (_proc_entry_list == NULL)
         goto ok;
     if ((pe = _proc_entry_list) != NULL)
@@ -724,7 +729,7 @@ clixon_process_operation(clixon_handle  h,
                         goto done;
                 if (op == PROC_OP_START || op == PROC_OP_STOP || op == PROC_OP_RESTART){
                     pe->pe_operation = op;
-                    clixon_debug(CLIXON_DBG_DEFAULT, "scheduling name: %s pid:%d op: %s",
+                    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "scheduling name: %s pid:%d op: %s",
                                  name, pe->pe_pid,
                                  clicon_int2str(proc_operation_map, pe->pe_operation));
                     if (pe->pe_state==PROC_STATE_RUNNING &&
@@ -738,7 +743,7 @@ clixon_process_operation(clixon_handle  h,
                             kill(pe->pe_pid, SIGTERM);
                             delay = 1;
                         }
-                        clixon_debug(CLIXON_DBG_DEFAULT, "%s(%d) %s --%s--> %s",
+                        clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "%s(%d) %s --%s--> %s",
                                      pe->pe_name, pe->pe_pid,
                                      clicon_int2str(proc_state_map, pe->pe_state),
                                      clicon_int2str(proc_operation_map, pe->pe_operation),
@@ -749,7 +754,7 @@ clixon_process_operation(clixon_handle  h,
                     sched++;/* start: immediate stop/restart: not immediate: wait timeout */
                 }
                 else{
-                    clixon_debug(CLIXON_DBG_DEFAULT, "name:%s op %s cancelled by wrap", name, clicon_int2str(proc_operation_map, op0));
+                    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "name:%s op %s cancelled by wrap", name, clicon_int2str(proc_operation_map, op0));
                 }
                 break;          /* hit break here */
             }
@@ -760,7 +765,7 @@ clixon_process_operation(clixon_handle  h,
  ok:
     retval = 0;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_PROC, "retval:%d", retval);
     return retval;
 }
 
@@ -785,13 +790,13 @@ clixon_process_status(clixon_handle  h,
     char             timestr[28];
     int              match = 0;
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "name:%s", name);
+    clixon_debug(CLIXON_DBG_PROC, "name:%s", name);
 
     if (_proc_entry_list != NULL){
         pe = _proc_entry_list;
         do {
             if (strcmp(pe->pe_name, name) == 0){
-                clixon_debug(CLIXON_DBG_DEFAULT, "found %s pid:%d", name, pe->pe_pid);
+                clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "found %s pid:%d", name, pe->pe_pid);
                 /* Check if running */
                 run = 0;
                 if (pe->pe_pid && proc_op_run(pe->pe_pid, &run) < 0)
@@ -835,7 +840,7 @@ clixon_process_status(clixon_handle  h,
     }
     retval = 0;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_PROC, "retval:%d", retval);
     return retval;
 }
 
@@ -855,7 +860,7 @@ clixon_process_start_all(clixon_handle h)
     proc_operation   op;
     int              sched = 0; /* If set, process action should be scheduled, register a timeout */
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "");
+    clixon_debug(CLIXON_DBG_PROC, "");
     if (_proc_entry_list == NULL)
         goto ok;
     pe = _proc_entry_list;
@@ -866,7 +871,7 @@ clixon_process_start_all(clixon_handle h)
             if (pe->pe_callback(h, pe, &op) < 0)
                 goto done;
         if (op == PROC_OP_START){
-            clixon_debug(CLIXON_DBG_DEFAULT, "name:%s start", pe->pe_name);
+            clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "name:%s start", pe->pe_name);
             pe->pe_operation = op;
             sched++; /* Immediate dont delay for start */
         }
@@ -877,7 +882,7 @@ clixon_process_start_all(clixon_handle h)
  ok:
     retval = 0;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_PROC, "retval:%d", retval);
     return retval;
 }
 
@@ -902,12 +907,12 @@ clixon_process_sched(int           fd,
     int              isrunning; /* Process is actually running */
     int              sched = 0;
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "");
+    clixon_debug(CLIXON_DBG_PROC, "");
     if (_proc_entry_list == NULL)
         goto ok;
     pe = _proc_entry_list;
     do {
-        clixon_debug(CLIXON_DBG_DEFAULT, "name: %s pid:%d %s --op:%s-->",
+        clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "name: %s pid:%d %s --op:%s-->",
                      pe->pe_name, pe->pe_pid, clicon_int2str(proc_state_map, pe->pe_state), clicon_int2str(proc_operation_map, pe->pe_operation));
         /* Execute pending operations and not already exiting */
         if (pe->pe_operation != PROC_OP_NONE){
@@ -942,7 +947,7 @@ clixon_process_sched(int           fd,
                                                    pe->pe_uid, pe->pe_gid, pe->pe_fdkeep,
                                                    &pe->pe_pid) < 0)
                             goto done;
-                    clixon_debug(CLIXON_DBG_DEFAULT,
+                    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL,
                                  "%s(%d) %s --%s--> %s",
                                  pe->pe_name, pe->pe_pid,
                                  clicon_int2str(proc_state_map, pe->pe_state),
@@ -970,7 +975,7 @@ clixon_process_sched(int           fd,
                                                pe->pe_uid, pe->pe_gid, pe->pe_fdkeep,
                                                &pe->pe_pid) < 0)
                         goto done;
-                    clixon_debug(CLIXON_DBG_DEFAULT,
+                    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL,
                                  "%s(%d) %s --%s--> %s",
                                  pe->pe_name, pe->pe_pid,
                                  clicon_int2str(proc_state_map, pe->pe_state),
@@ -994,7 +999,7 @@ clixon_process_sched(int           fd,
  ok:
     retval = 0;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_PROC, "retval:%d", retval);
     return retval;
 }
 
@@ -1016,7 +1021,7 @@ clixon_process_sched_register(clixon_handle h,
     struct timeval t;
     struct timeval t1 = {0, 100000}; /* 100ms */
 
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "");
+    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "");
     gettimeofday(&t, NULL);
     if (delay)
         timeradd(&t, &t1, &t);
@@ -1024,7 +1029,7 @@ clixon_process_sched_register(clixon_handle h,
         goto done;
     retval = 0;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT | CLIXON_DBG_DETAIL, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "retval:%d", retval);
     return retval;
 }
 
@@ -1045,12 +1050,12 @@ clixon_process_waitpid(clixon_handle h)
     int              status = 0;
     pid_t            wpid;
 
-    clixon_debug(CLIXON_DBG_DEFAULT, "");
+    clixon_debug(CLIXON_DBG_PROC, "");
     if (_proc_entry_list == NULL)
         goto ok;
     if ((pe = _proc_entry_list) != NULL)
         do {
-            clixon_debug(CLIXON_DBG_DEFAULT, "%s(%d) %s op:%s",
+            clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "%s(%d) %s op:%s",
                          pe->pe_name, pe->pe_pid,
                          clicon_int2str(proc_state_map, pe->pe_state),
                          clicon_int2str(proc_operation_map, pe->pe_operation));
@@ -1058,15 +1063,15 @@ clixon_process_waitpid(clixon_handle h)
                 && (pe->pe_state == PROC_STATE_RUNNING || pe->pe_state == PROC_STATE_EXITING)
                 //      && (pe->pe_operation == PROC_OP_STOP || pe->pe_operation == PROC_OP_RESTART)
                 ){
-                clixon_debug(CLIXON_DBG_DEFAULT, "%s waitpid(%d)",
+                clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "%s waitpid(%d)",
                              pe->pe_name, pe->pe_pid);
                 if ((wpid = waitpid(pe->pe_pid, &status, WNOHANG)) == pe->pe_pid){
-                    clixon_debug(CLIXON_DBG_DEFAULT, "waitpid(%d) waited", pe->pe_pid);
+                    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "waitpid(%d) waited", pe->pe_pid);
                     pe->pe_exit_status = status;
                     switch (pe->pe_operation){
                     case PROC_OP_NONE: /* Spontaneous / External termination */
                     case PROC_OP_STOP:
-                        clixon_debug(CLIXON_DBG_DEFAULT,
+                        clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL,
                                      "%s(%d) %s --%s--> %s",
                                      pe->pe_name, pe->pe_pid,
                                      clicon_int2str(proc_state_map, pe->pe_state),
@@ -1085,7 +1090,7 @@ clixon_process_waitpid(clixon_handle h)
                                                    &pe->pe_pid) < 0)
                             goto done;
                         gettimeofday(&pe->pe_starttime, NULL);
-                        clixon_debug(CLIXON_DBG_DEFAULT, "%s(%d) %s --%s--> %s",
+                        clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "%s(%d) %s --%s--> %s",
                                      pe->pe_name, pe->pe_pid,
                                      clicon_int2str(proc_state_map, pe->pe_state),
                                      clicon_int2str(proc_operation_map, pe->pe_operation),
@@ -1101,7 +1106,7 @@ clixon_process_waitpid(clixon_handle h)
                     break; /* pid is unique */
                 }
                 else
-                    clixon_debug(CLIXON_DBG_DEFAULT, "waitpid(%d) nomatch:%d",
+                    clixon_debug(CLIXON_DBG_PROC | CLIXON_DBG_DETAIL, "waitpid(%d) nomatch:%d",
                                  pe->pe_pid, wpid);
             }
             pe = NEXTQ(process_entry_t *, pe);
@@ -1109,7 +1114,7 @@ clixon_process_waitpid(clixon_handle h)
  ok:
     retval = 0;
  done:
-    clixon_debug(CLIXON_DBG_DEFAULT, "retval:%d", retval);
+    clixon_debug(CLIXON_DBG_PROC, "retval:%d", retval);
     return retval;
 }
 


### PR DESCRIPTION
NACM generates a lot of noise but you rarely need its logging unless you're debugging it specifically.
