### PR TITLE
Remove null terminator for SNMP octet string

### DIFF
--- a/apps/snmp/snmp_lib.c
+++ b/apps/snmp/snmp_lib.c
@@ -917,11 +917,12 @@ type_xml2snmp(char       *snmpstr,
         break;
     }
     case ASN_OCTET_STR: // 4
-        *snmplen = strlen(snmpstr)+1;
-        if ((*snmpval = (u_char*)strdup((snmpstr))) == NULL){
-            clixon_err(OE_UNIX, errno, "strdup");
+        *snmplen = strlen(snmpstr);
+        if ((*snmpval = malloc(*snmplen)) == NULL){
+            clixon_err(OE_UNIX, errno, "malloc");
             goto done;
         }
+        memcpy(*snmpval, snmpstr, *snmplen);
         break;
     case ASN_COUNTER64:{ // 0x46 / 70
         uint64_t u64;

--- a/test/test_snmp_get.sh
+++ b/test/test_snmp_get.sh
@@ -279,13 +279,13 @@ new "Test SNMP get nsIETFWGName"
 validate_oid $OID15 $OID15 "INTEGER" 42
 
 new "Test SNMP getnext nsIETFWGName"
-expectpart "$($snmpgetnext $OID15)" 0 "Hex-STRING: 4E 61 6D 65 31 00"
+expectpart "$($snmpgetnext $OID15)" 0 "STRING: \"Name1\""
 
 new "Test SNMP getnext netSnmpHostsTable"
-expectpart "$($snmpgetnext $OID18)" 0 "$OID19 = Hex-STRING: 74 65 73 74 00"
+expectpart "$($snmpgetnext $OID18)" 0 "$OID19 = STRING: \"test\""
 
 new "Test SNMP get netSnmpHostName"
-expectpart "$($snmpget $OID19)" 0 "$OID19 = Hex-STRING: 74 65 73 74 00"
+expectpart "$($snmpget $OID19)" 0 "$OID19 = STRING: \"test\""
 
 new "Test SNMP getnext netSnmpHostName"
 expectpart "$($snmpgetnext $OID19)" 0 "$OID20 = INTEGER: 1"


### PR DESCRIPTION
In the SNMP protocol all tranfered values (bindings) have a defined length. Therefore the octet string does not need a null terminator. If there is one, it is transfered as control character and may confuse SNMP agents like snmp4j. (snmpget shows a "." character at the end what ist not correct.)

Check the result without and with this fix ("." at the end of "Some string value")

```
--> Without this fix:
$ snmpget -v2c -c private localhost SIMPLE-MIB::testAlphaOneConfstring.0
SIMPLE-MIB::testAlphaOneConfstring.0 = STRING: Some string value.

--> With this fix:
$ snmpget -v2c -c private localhost SIMPLE-MIB::testAlphaOneConfstring.0
SIMPLE-MIB::testAlphaOneConfstring.0 = STRING: Some string value
```