### PR TITLE
Use yacc and lex as detected by autoconf to build restconf

### DIFF
--- a/apps/restconf/Makefile.in
+++ b/apps/restconf/Makefile.in
@@ -83,6 +83,9 @@ LIBDEPS		= $(top_srcdir)/lib/src/$(CLIXON_LIB)
 
 LIBS          = -L$(top_srcdir)/lib/src $(top_srcdir)/lib/src/$(CLIXON_LIB) @LIBS@ 
 
+YACC		= @YACC@
+LEX		= @LEX@
+
 CPPFLAGS  	= @CPPFLAGS@
 
 


### PR DESCRIPTION
Setup YACC and LEX via autoconf
On opensuse tumbleweed I had a build error because the wrong lex variant was used without this.

This is the same as in lib/src/Makefile.in