### PR TITLE
Add run python3

### DIFF
--- a/apps/cli/cli_common.c
+++ b/apps/cli/cli_common.c
@@ -823,7 +823,7 @@ int cli_start_python3(clixon_handle h, cvec *cvv, cvec *argv) {
         perror("Error run script");
         exit(0);
     }
-    /* Ждем завершения дочернего процесса */
+
     if (waitpid(pid, &status, 0) == pid)
         ret = WEXITSTATUS(status);
     else

--- a/apps/cli/clixon_cli_api.h
+++ b/apps/cli/clixon_cli_api.h
@@ -97,6 +97,7 @@ int cli_debug_backend(clixon_handle h, cvec *vars, cvec *argv);
 int cli_debug_restconf(clixon_handle h, cvec *vars, cvec *argv);
 int cli_set_mode(clixon_handle h, cvec *vars, cvec *argv);
 int cli_start_shell(clixon_handle h, cvec *vars, cvec *argv);
+int cli_start_python3(clixon_handle h, cvec *vars, cvec *argv);
 int cli_quit(clixon_handle h, cvec *vars, cvec *argv);
 int cli_commit(clixon_handle h, cvec *vars, cvec *argv);
 int cli_validate(clixon_handle h, cvec *vars, cvec *argv);

--- a/configure
+++ b/configure
@@ -5302,11 +5302,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++11 features" >&5
 printf %s "checking for $CXX option to enable C++11 features... " >&6; }
-if test ${ac_cv_prog_cxx_11+y}
+if test ${ac_cv_prog_cxx_cxx11+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_11=no
+  ac_cv_prog_cxx_cxx11=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -5348,11 +5348,11 @@ if test x$ac_prog_cxx_stdcxx = xno
 then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CXX option to enable C++98 features" >&5
 printf %s "checking for $CXX option to enable C++98 features... " >&6; }
-if test ${ac_cv_prog_cxx_98+y}
+if test ${ac_cv_prog_cxx_cxx98+y}
 then :
   printf %s "(cached) " >&6
 else $as_nop
-  ac_cv_prog_cxx_98=no
+  ac_cv_prog_cxx_cxx98=no
 ac_save_CXX=$CXX
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */

--- a/example/main/example_cli.cli
+++ b/example/main/example_cli.cli
@@ -71,6 +71,10 @@ debug("Debugging parts of the system"){
 shell("System command"), cli_start_shell("bash");{
   <source:rest>("Single shell command"), cli_start_shell("bash");
 }
+python3("Path to script"), cli_start_python3("path");{
+    <source:rest>("Path to script"), cli_start_python3("path");
+}
+
 copy("Copy and create a new object") {
     running("Copy from running db")  startup("Copy to startup config"), db_copy("running", "startup");
     interface("Copy interface"){


### PR DESCRIPTION
This commit includes a new function `cli_start_python3` which executes Python3 scripts from within the CLI. The function operates as a new command in the CLI interface, accepting a path to the script as an argument. This enhancement improves the versatility of the Clixon CLI interface by allowing direct execution of Python scripts.