### PR TITLE
[RFC] Backend minor rework and improvement

### DIFF
--- a/apps/backend/backend_commit.c
+++ b/apps/backend/backend_commit.c
@@ -555,34 +555,32 @@ td_find_changed_namespaces(clixon_handle       h,
     while (xntgt || xnsrc) {
         if (xnsrc && xml_flag(xnsrc, XML_FLAG_DEL)) {
             ns = xml_nsxml_fetch(xnsrc);
-            if (!ns)
-                continue;
-            if (clixon_plugin_ns_present(h, ns)) {
-                if ((td2 = transaction_new()) == NULL)
-                    goto fail;
-                td2->td_src = xnsrc;
-                if ((td2->td_dvec = malloc(sizeof(cxobj *))) == NULL)
-                    goto fail;
-                td2->td_dvec[0] = xnsrc;
-                td2->td_dlen = 1;
-            }
-            if (xnsrc)
-                xnsrc = xml_child_each(td->td_src, xnsrc, CX_ELMNT);
+            if (ns) {
+		if (clixon_plugin_ns_present(h, ns)) {
+		    if ((td2 = transaction_new()) == NULL)
+			goto fail;
+		    td2->td_src = xnsrc;
+		    if ((td2->td_dvec = malloc(sizeof(cxobj *))) == NULL)
+			goto fail;
+		    td2->td_dvec[0] = xnsrc;
+		    td2->td_dlen = 1;
+		}
+	    }
+	    xnsrc = xml_child_each(td->td_src, xnsrc, CX_ELMNT);
         } else if (xntgt && xml_flag(xntgt, XML_FLAG_ADD)) {
             ns = xml_nsxml_fetch(xntgt);
-            if (!ns)
-                continue;
-            if (clixon_plugin_ns_present(h, ns)) {
-                if ((td2 = transaction_new()) == NULL)
-                    goto fail;
-                td2->td_target = xntgt;
-                if ((td2->td_avec = malloc(sizeof(cxobj *))) == NULL)
-                    goto fail;
-                td2->td_avec[0] = xntgt;
-                td2->td_alen = 1;
-            }
-            if (xntgt)
-                xntgt = xml_child_each(td->td_target, xntgt, CX_ELMNT);
+            if (ns) {
+		if (clixon_plugin_ns_present(h, ns)) {
+		    if ((td2 = transaction_new()) == NULL)
+			goto fail;
+		    td2->td_target = xntgt;
+		    if ((td2->td_avec = malloc(sizeof(cxobj *))) == NULL)
+			goto fail;
+		    td2->td_avec[0] = xntgt;
+		    td2->td_alen = 1;
+		}
+	    }
+	    xntgt = xml_child_each(td->td_target, xntgt, CX_ELMNT);
         } else {
             if ((xntgt && xml_flag(xntgt, XML_FLAG_CHANGE)) ||
                 (xnsrc && xml_flag(xnsrc, XML_FLAG_CHANGE))) {
@@ -592,29 +590,29 @@ td_find_changed_namespaces(clixon_handle       h,
                 }
                 ns = xml_nsxml_fetch(xntgt);
                 ns2 = xml_nsxml_fetch(xnsrc);
-                if (!ns && !ns2)
-                    continue;
-                if (!ns || !ns2 || strcmp(ns, ns2) != 0) {
-                    clixon_err(OE_XML, EINVAL, "xntgt/xnsrc ns mismatch");
-                    goto fail;
-                }
-                if (clixon_plugin_ns_present(h, ns)) {
-                    if ((td2 = transaction_new()) == NULL)
-                        goto fail;
-                    td2->td_src = xnsrc;
-                    td2->td_target = xntgt;
-                    if (xml_diff(td2->td_src,
-                                 td2->td_target,
-                                 &td2->td_dvec,      /* removed: only in running */
-                                 &td2->td_dlen,
-                                 &td2->td_avec,      /* added: only in candidate */
-                                 &td2->td_alen,
-                                 &td2->td_scvec,     /* changed: original values */
-                                 &td2->td_tcvec,     /* changed: wanted values */
-                                 &td2->td_clen) < 0)
-                        goto fail;
-                }
-            }
+                if (ns || ns2) {
+		    if (!ns || !ns2 || strcmp(ns, ns2) != 0) {
+			clixon_err(OE_XML, EINVAL, "xntgt/xnsrc ns mismatch");
+			goto fail;
+		    }
+		    if (clixon_plugin_ns_present(h, ns)) {
+			if ((td2 = transaction_new()) == NULL)
+			    goto fail;
+			td2->td_src = xnsrc;
+			td2->td_target = xntgt;
+			if (xml_diff(td2->td_src,
+				     td2->td_target,
+				     &td2->td_dvec,      /* removed: only in running */
+				     &td2->td_dlen,
+				     &td2->td_avec,      /* added: only in candidate */
+				     &td2->td_alen,
+				     &td2->td_scvec,     /* changed: original values */
+				     &td2->td_tcvec,     /* changed: wanted values */
+				     &td2->td_clen) < 0)
+			    goto fail;
+		    }
+		}
+	    }
             if (xntgt)
                 xntgt = xml_child_each(td->td_target, xntgt, CX_ELMNT);
             if (xnsrc)

--- a/apps/backend/backend_plugin_restconf.c
+++ b/apps/backend/backend_plugin_restconf.c
@@ -451,7 +451,7 @@ backend_plugin_restconf_register(clixon_handle h,
         .ca_trans_commit = restconf_pseudo_process_commit
     };
 
-    if (clixon_add_plugin(h, "restconf pseudo plugin", &api, NULL) < 0)
+    if (clixon_add_plugin(h, "restconf pseudo plugin", NULL, &api, NULL) < 0)
         goto done;
 
     /* Register generic process-control of restconf daemon, ie start/stop restconf */

--- a/apps/backend/backend_plugin_restconf.c
+++ b/apps/backend/backend_plugin_restconf.c
@@ -446,13 +446,13 @@ backend_plugin_restconf_register(clixon_handle h,
                                  yang_stmt    *yspec)
 {
     int              retval = -1;
-    clixon_plugin_t *cp = NULL;
+    clixon_plugin_api api = {
+        .ca_trans_validate = restconf_pseudo_process_validate,
+        .ca_trans_commit = restconf_pseudo_process_commit
+    };
 
-    if (clixon_pseudo_plugin(h, "restconf pseudo plugin", &cp) < 0)
+    if (clixon_add_plugin(h, "restconf pseudo plugin", &api, NULL) < 0)
         goto done;
-
-    clixon_plugin_api_get(cp)->ca_trans_validate = restconf_pseudo_process_validate;
-    clixon_plugin_api_get(cp)->ca_trans_commit = restconf_pseudo_process_commit;
 
     /* Register generic process-control of restconf daemon, ie start/stop restconf */
     if (restconf_pseudo_process_control(h) < 0)

--- a/apps/backend/clixon_backend_plugin.h
+++ b/apps/backend/clixon_backend_plugin.h
@@ -66,6 +66,14 @@ typedef struct {
     cxobj    **td_scvec;    /* Source changed xml vector */
     cxobj    **td_tcvec;    /* Target changed xml vector */
     int        td_clen;     /* Changed xml vector length */
+
+    /*
+     * Changed namespaces.  This is a cvec of pointers to cvecs
+     * indexed by the namespace name.  The cvecs that are sub-members
+     * here are a list of transaction_data_t structures for each
+     * matching top-level xml tree with a matching namespace.
+     */
+    cvec      *td_nss;
 } transaction_data_t;
 
 /*! Pagination userdata 

--- a/apps/restconf/restconf_main_fcgi.c
+++ b/apps/restconf/restconf_main_fcgi.c
@@ -515,7 +515,7 @@ main(int    argc,
     /* Create a pseudo-plugin to create extension callback to set the ietf-routing
      * yang-data extension for api-root top-level restconf function.
      */
-    if (clixon_add_plugin(h, "pseudo restconf", &api, NULL) < 0)
+    if (clixon_add_plugin(h, "pseudo restconf", NULL, &api, NULL) < 0)
         goto done;
 
     /* Load Yang modules

--- a/apps/restconf/restconf_main_fcgi.c
+++ b/apps/restconf/restconf_main_fcgi.c
@@ -329,6 +329,8 @@ main(int    argc,
     enum format_enum config_dump_format = FORMAT_XML;
     int              print_version = 0;
     int              stream_timeout = 0;
+
+    clixon_plugin_api api = { .ca_extension = restconf_main_extension_cb };
     
     /* Create handle */
     if ((h = restconf_handle_init()) == NULL)
@@ -513,9 +515,8 @@ main(int    argc,
     /* Create a pseudo-plugin to create extension callback to set the ietf-routing
      * yang-data extension for api-root top-level restconf function.
      */
-    if (clixon_pseudo_plugin(h, "pseudo restconf", &cp) < 0)
+    if (clixon_add_plugin(h, "pseudo restconf", &api, NULL) < 0)
         goto done;
-    clixon_plugin_api_get(cp)->ca_extension = restconf_main_extension_cb;
 
     /* Load Yang modules
      * 1. Load a yang module as a specific absolute filename */

--- a/apps/restconf/restconf_main_native.c
+++ b/apps/restconf/restconf_main_native.c
@@ -980,7 +980,7 @@ restconf_clixon_init(clixon_handle h,
     /* Create a pseudo-plugin to create extension callback to set the ietf-routing
      * yang-data extension for api-root top-level restconf function.
      */
-    if (clixon_add_plugin(h, "pseudo restconf", &api, NULL) < 0)
+    if (clixon_add_plugin(h, "pseudo restconf", NULL, &api, NULL) < 0)
         goto done;
 
     /* Load Yang modules

--- a/apps/restconf/restconf_main_native.c
+++ b/apps/restconf/restconf_main_native.c
@@ -934,13 +934,14 @@ restconf_clixon_init(clixon_handle h,
     size_t         cligen_buflen;
     size_t         cligen_bufthreshold;
     yang_stmt     *yspec = NULL;
-    clixon_plugin_t *cp = NULL;
     char          *str;
     cvec          *nsctx_global = NULL; /* Global namespace context */
     cxobj         *xrestconf = NULL;
     cxobj         *xerr = NULL;
     int            ret;
     size_t         sz;
+
+    clixon_plugin_api api = { .ca_extension = restconf_main_extension_cb };
 
     /* Set default namespace according to CLICON_NAMESPACE_NETCONF_DEFAULT */
     xml_nsctx_namespace_netconf_default(h);
@@ -979,9 +980,8 @@ restconf_clixon_init(clixon_handle h,
     /* Create a pseudo-plugin to create extension callback to set the ietf-routing
      * yang-data extension for api-root top-level restconf function.
      */
-    if (clixon_pseudo_plugin(h, "pseudo restconf", &cp) < 0)
+    if (clixon_add_plugin(h, "pseudo restconf", &api, NULL) < 0)
         goto done;
-    clixon_plugin_api_get(cp)->ca_extension = restconf_main_extension_cb;
 
     /* Load Yang modules
      * 1. Load a yang module as a specific absolute filename */

--- a/lib/clixon/clixon_plugin.h
+++ b/lib/clixon/clixon_plugin.h
@@ -483,6 +483,8 @@ char            *clixon_plugin_ns_get(clixon_plugin_t *cp);
 char            *clixon_plugin_name_get(clixon_plugin_t *cp);
 plghndl_t        clixon_plugin_handle_get(clixon_plugin_t *cp);
 
+int              clixon_plugin_ns_present(clixon_handle h, const char *ns);
+
 clixon_plugin_t *clixon_plugin_each(clixon_handle h, clixon_plugin_t *cpprev);
 
 clixon_plugin_t *clixon_plugin_each_revert(clixon_handle h, clixon_plugin_t *cpprev, int nr);

--- a/lib/clixon/clixon_plugin.h
+++ b/lib/clixon/clixon_plugin.h
@@ -492,6 +492,9 @@ int clixon_plugins_load(clixon_handle h, const char *function, const char *dir, 
 
 int clixon_pseudo_plugin(clixon_handle h, const char *name, clixon_plugin_t **cpp);
 
+int clixon_add_plugin(clixon_handle h, const char *name, clixon_plugin_api *api, clixon_plugin_t **cpp);
+int clixon_remove_plugin(clixon_handle h, clixon_plugin_t *cp);
+
 int clixon_plugin_start_one(clixon_plugin_t *cp, clixon_handle h);
 int clixon_plugin_start_all(clixon_handle h);
 

--- a/lib/clixon/clixon_plugin.h
+++ b/lib/clixon/clixon_plugin.h
@@ -479,6 +479,7 @@ typedef struct {
 clixon_plugin_api *clixon_plugin_init(clixon_handle h);
 
 clixon_plugin_api *clixon_plugin_api_get(clixon_plugin_t *cp);
+char            *clixon_plugin_ns_get(clixon_plugin_t *cp);
 char            *clixon_plugin_name_get(clixon_plugin_t *cp);
 plghndl_t        clixon_plugin_handle_get(clixon_plugin_t *cp);
 
@@ -492,7 +493,7 @@ int clixon_plugins_load(clixon_handle h, const char *function, const char *dir, 
 
 int clixon_pseudo_plugin(clixon_handle h, const char *name, clixon_plugin_t **cpp);
 
-int clixon_add_plugin(clixon_handle h, const char *name, clixon_plugin_api *api, clixon_plugin_t **cpp);
+int clixon_add_plugin(clixon_handle h, const char *name, const char *ns, clixon_plugin_api *api, clixon_plugin_t **cpp);
 int clixon_remove_plugin(clixon_handle h, clixon_plugin_t *cp);
 
 int clixon_plugin_start_one(clixon_plugin_t *cp, clixon_handle h);

--- a/lib/src/clixon_plugin.c
+++ b/lib/src/clixon_plugin.c
@@ -377,10 +377,8 @@ plugin_load_one(clixon_handle     h,
     /* Copy name to struct */
     snprintf(cp->cp_name, sizeof(cp->cp_name), "%s", name);
     cp->cp_api = *api;
-    if (cp){
-        *cpp = cp;
-        cp = NULL;
-    }
+    *cpp = cp;
+    cp = NULL;
     retval = 1;
  done:
     clixon_debug(CLIXON_DBG_INIT | CLIXON_DBG_DETAIL, "retval:%d", retval);

--- a/lib/src/clixon_plugin.c
+++ b/lib/src/clixon_plugin.c
@@ -582,10 +582,10 @@ clixon_plugin_exit_one(clixon_plugin_t *cp,
         }
         if (clixon_resource_check(h, &wh, cp->cp_name, __FUNCTION__) < 0)
             goto done;
-        if (dlclose(cp->cp_handle) != 0) {
-            error = (char*)dlerror();
-            clixon_err(OE_PLUGIN, errno, "dlclose: %s", error ? error : "Unknown error");
-        }
+    }
+    if (cp->cp_handle && dlclose(cp->cp_handle) != 0) {
+        error = (char*)dlerror();
+        clixon_err(OE_PLUGIN, errno, "dlclose: %s", error ? error : "Unknown error");
     }
     retval = 0;
  done:

--- a/lib/src/clixon_yang_module.c
+++ b/lib/src/clixon_yang_module.c
@@ -819,18 +819,12 @@ yang_metadata_annotation_check(cxobj     *xa,
 int
 yang_metadata_init(clixon_handle h)
 {
-    int              retval = -1;
-    clixon_plugin_t *cp = NULL;
+    clixon_plugin_api api = { .ca_extension = ietf_yang_metadata_extension_cb };
 
     /* Create a pseudo-plugin to create extension callback to set the ietf-yang-meta
      * yang-data extension for api-root top-level restconf function.
      */
-    if (clixon_pseudo_plugin(h, "pseudo yang metadata", &cp) < 0)
-        goto done;
-    clixon_plugin_api_get(cp)->ca_extension = ietf_yang_metadata_extension_cb;
-    retval = 0;
- done:
-    return retval;
+    return clixon_add_plugin(h, "pseudo yang metadata", &api, NULL);
 }
 
 /*! Given yang-lib module-set XML tree, parse modules into an yspec

--- a/lib/src/clixon_yang_module.c
+++ b/lib/src/clixon_yang_module.c
@@ -824,7 +824,7 @@ yang_metadata_init(clixon_handle h)
     /* Create a pseudo-plugin to create extension callback to set the ietf-yang-meta
      * yang-data extension for api-root top-level restconf function.
      */
-    return clixon_add_plugin(h, "pseudo yang metadata", &api, NULL);
+    return clixon_add_plugin(h, "pseudo yang metadata", NULL, &api, NULL);
 }
 
 /*! Given yang-lib module-set XML tree, parse modules into an yspec


### PR DESCRIPTION
I've been studying the backend and I found a few things.

The first two patches fix a bug and remove unnecessary code.

The next patch applies the DRY principle and consolidates some code.

The last two patches give an alternate interface to clixon_pseudo_plugin() that results in less code being used to call it, and replaces all the calls.  It also lets you add plugins from a loadable module and automatically cleans up any added plugins on a failure.

I've been looking at this because I have been looking at using clixon.  One thing I would like is the ability to have per-namespace backend plugins.  I think this makes sense (though I'm not 100% sure); this way we could have individual plugins  for each namespace without each plugin having to scan the entire XML tree for what they need.

It's also not completely clear to me  how to use the add/remove/change part of a transaction.  You are only getting a little bit of data.  You can search up the parents to find where you are in the tree, but it seems inefficient to have to do this on every plugin.  But that seems to be the only way you could use this.  Again, being able to do this on a per-namespace basis would seem more efficient.