### PR TITLE
General fixes for clixon

### DIFF
--- a/lib/src/clixon_plugin.c
+++ b/lib/src/clixon_plugin.c
@@ -377,10 +377,8 @@ plugin_load_one(clixon_handle     h,
     /* Copy name to struct */
     snprintf(cp->cp_name, sizeof(cp->cp_name), "%s", name);
     cp->cp_api = *api;
-    if (cp){
-        *cpp = cp;
-        cp = NULL;
-    }
+    *cpp = cp;
+    cp = NULL;
     retval = 1;
  done:
     clixon_debug(CLIXON_DBG_INIT | CLIXON_DBG_DETAIL, "retval:%d", retval);

--- a/lib/src/clixon_plugin.c
+++ b/lib/src/clixon_plugin.c
@@ -582,10 +582,10 @@ clixon_plugin_exit_one(clixon_plugin_t *cp,
         }
         if (clixon_resource_check(h, &wh, cp->cp_name, __FUNCTION__) < 0)
             goto done;
-        if (dlclose(cp->cp_handle) != 0) {
-            error = (char*)dlerror();
-            clixon_err(OE_PLUGIN, errno, "dlclose: %s", error ? error : "Unknown error");
-        }
+    }
+    if (cp->cp_handle && dlclose(cp->cp_handle) != 0) {
+        error = (char*)dlerror();
+        clixon_err(OE_PLUGIN, errno, "dlclose: %s", error ? error : "Unknown error");
     }
     retval = 0;
  done:


### PR DESCRIPTION
These are some things I ran into while working in clixon.  They consolidate common code and remove unnecessary stuff, mostly.

There is one thing I think is a bug fix.  If you don't have an exit function for an API, it will not unload the module.  Is that intended?  If so, it should probably be documented.