### PR TITLE
Check libcrypto before libssl to avoid configure errors

### DIFF
--- a/configure
+++ b/configure
@@ -6664,51 +6664,6 @@ fi
 
 
 # This is for digest / restconf
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OPENSSL_init_ssl  in -lssl" >&5
-printf %s "checking for OPENSSL_init_ssl  in -lssl... " >&6; }
-if test ${ac_cv_lib_ssl_OPENSSL_init_ssl_+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lssl  $LIBS"
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-/* Override any GCC internal prototype to avoid an error.
-   Use char because int might match the return type of a GCC
-   builtin and then its argument prototype would still apply.  */
-char OPENSSL_init_ssl  ();
-int
-main (void)
-{
-return OPENSSL_init_ssl  ();
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  ac_cv_lib_ssl_OPENSSL_init_ssl_=yes
-else $as_nop
-  ac_cv_lib_ssl_OPENSSL_init_ssl_=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ssl_OPENSSL_init_ssl_" >&5
-printf "%s\n" "$ac_cv_lib_ssl_OPENSSL_init_ssl_" >&6; }
-if test "x$ac_cv_lib_ssl_OPENSSL_init_ssl_" = xyes
-then :
-  printf "%s\n" "#define HAVE_LIBSSL 1" >>confdefs.h
-
-  LIBS="-lssl $LIBS"
-
-else $as_nop
-  as_fn_error $? "libssl missing" "$LINENO" 5
-fi
-
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for CRYPTO_new_ex_data in -lcrypto" >&5
 printf %s "checking for CRYPTO_new_ex_data in -lcrypto... " >&6; }
 if test ${ac_cv_lib_crypto_CRYPTO_new_ex_data+y}
@@ -6752,6 +6707,51 @@ then :
 
 else $as_nop
   as_fn_error $? "libcrypto missing" "$LINENO" 5
+fi
+
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for OPENSSL_init_ssl  in -lssl" >&5
+printf %s "checking for OPENSSL_init_ssl  in -lssl... " >&6; }
+if test ${ac_cv_lib_ssl_OPENSSL_init_ssl_+y}
+then :
+  printf %s "(cached) " >&6
+else $as_nop
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lssl  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+char OPENSSL_init_ssl  ();
+int
+main (void)
+{
+return OPENSSL_init_ssl  ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  ac_cv_lib_ssl_OPENSSL_init_ssl_=yes
+else $as_nop
+  ac_cv_lib_ssl_OPENSSL_init_ssl_=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_ssl_OPENSSL_init_ssl_" >&5
+printf "%s\n" "$ac_cv_lib_ssl_OPENSSL_init_ssl_" >&6; }
+if test "x$ac_cv_lib_ssl_OPENSSL_init_ssl_" = xyes
+then :
+  printf "%s\n" "#define HAVE_LIBSSL 1" >>confdefs.h
+
+  LIBS="-lssl $LIBS"
+
+else $as_nop
+  as_fn_error $? "libssl missing" "$LINENO" 5
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 #
 # ***** BEGIN LICENSE BLOCK *****
-# 
+#
 # Copyright (C) 2009-2016 Olof Hagsand and Benny Holmgren
 # Copyright (C) 2017-2019 Olof Hagsand
 # Copyright (C) 2020-2023 Olof Hagsand and Rubicon Communications, LLC
@@ -24,7 +24,7 @@
 # in which case the provisions of the GPL are applicable instead
 # of those above. If you wish to allow use of your version of this file only
 # under the terms of the GPL, and not to allow others to
-# use your version of this file under the terms of Apache License version 2, 
+# use your version of this file under the terms of Apache License version 2,
 # indicate your decision by deleting the provisions above and replace them with
 # the notice and other provisions required by the GPL. If you do not delete
 # the provisions above, a recipient may use your version of this file under
@@ -58,16 +58,16 @@ CLIXON_VERSION_PATCH="0"
 AC_ARG_ENABLE(debug, AS_HELP_STRING([--enable-debug],[Build with debug symbols, default: no]),[
 	  if test "$enableval" = no; then
 	      ac_enable_debug=no
-	  else	      
+	  else
 	      ac_enable_debug=yes
           fi
         ],
 	[ ac_enable_debug=no])
 
-AC_MSG_RESULT(debug is $ac_enable_debug)	
+AC_MSG_RESULT(debug is $ac_enable_debug)
 if test "$ac_enable_debug" = "yes"; then
    : ${CFLAGS="-g -Wall"}
-   INSTALLFLAGS=""	
+   INSTALLFLAGS=""
 else
    : ${CFLAGS="-O2 -Wall"}
 fi
@@ -80,7 +80,7 @@ AC_DEFINE_UNQUOTED(CLIXON_VERSION_PATCH, $CLIXON_VERSION_PATCH, [Clixon path ver
 
 AC_CHECK_LIB(m, main)
 
-# defines: target_cpu, target_vendor, and target_os. 
+# defines: target_cpu, target_vendor, and target_os.
 AC_CANONICAL_TARGET
 
 # AC_SUBST(var) makes @var@ appear in makefiles.
@@ -116,7 +116,7 @@ AC_SUBST(with_libxml2)
 AC_SUBST(LIBXML2_CFLAGS)
 AC_SUBST(CLIXON_YANG_PATCH)
 # Where Clixon installs its YANG specs
-AC_SUBST(YANG_INSTALLDIR) 
+AC_SUBST(YANG_INSTALLDIR)
 # Examples require standard IETF YANGs. You need to provide these for example and tests
 AC_SUBST(YANG_STANDARD_DIR)
 # SNMP tests require generated YANGs from MIBs
@@ -138,12 +138,12 @@ AC_PROG_CXX
 
 CPPFLAGS="-DHAVE_CONFIG_H ${CPPFLAGS}"
 
-AC_MSG_RESULT(compiler is $CC)	
+AC_MSG_RESULT(compiler is $CC)
 
-AC_MSG_RESULT(CPPFLAGS is $CPPFLAGS)	
+AC_MSG_RESULT(CPPFLAGS is $CPPFLAGS)
 AC_MSG_RESULT(CFLAGS is $CFLAGS)
 AC_MSG_RESULT(LDFLAGS is $LDFLAGS)
-AC_MSG_RESULT(INSTALLFLAGS is $INSTALLFLAGS)	
+AC_MSG_RESULT(INSTALLFLAGS is $INSTALLFLAGS)
 
 AC_PROG_YACC
 AC_PROG_LEX(noyywrap)
@@ -180,9 +180,9 @@ if test "$exec_prefix" = "NONE"; then
      exec_prefix=${prefix}
 fi
 
-# Postfix for shared libs 
+# Postfix for shared libs
 SH_SUFFIX=".so"
-# Postfix for static libs 
+# Postfix for static libs
 LIBSTATIC_SUFFIX=".a"
 
 # Expand for easy replacement in example/main/example.xml.in
@@ -211,7 +211,7 @@ fi
 AC_ARG_ENABLE(yang-patch, AS_HELP_STRING([--enable-yang-patch],[Enable YANG patch, RFC 8072, default: no]),[
 	  if test "$enableval" = no; then
 	      enable_yang_patch=no
-	  else	      
+	  else
 	      enable_yang_patch=yes
           fi
         ],
@@ -226,13 +226,13 @@ fi
 # Check curl, needed for tests but not for clixon core
 AC_CHECK_HEADERS(curl/curl.h,[])
 AC_CHECK_LIB(curl, curl_global_init)
-   
-# Experimental: Curl publish notification stream to eg Nginx nchan. 
+
+# Experimental: Curl publish notification stream to eg Nginx nchan.
 AC_ARG_ENABLE(publish, AS_HELP_STRING([--enable-publish],
 	[Enable publish of notification streams using SSE and curl]),[
 	  if test "$enableval" = no; then
 	      ac_enable_publish=no
-	  else	      
+	  else
 	      ac_enable_publish=yes
           fi
         ],
@@ -272,14 +272,14 @@ AC_MSG_RESULT(restconf mode ${with_restconf})
 # Actions for each specific package
 if test "x${with_restconf}" = xfcgi; then
    # Lives in libfcgi-dev
-   AC_CHECK_LIB(fcgi, FCGX_Init,, AC_MSG_ERROR([libfcgi-dev missing])) 
+   AC_CHECK_LIB(fcgi, FCGX_Init,, AC_MSG_ERROR([libfcgi-dev missing]))
    AC_DEFINE(WITH_RESTCONF_FCGI, 1, [Use fcgi restconf mode]) # For c-code that cant use strings
 elif test "x${with_restconf}" = xnative; then
    # Check if http/1 enabled
    AC_ARG_ENABLE(http1, AS_HELP_STRING([--disable-http1],[Disable http1 for native restconf http/1, ie http/2 only]),[
    	  if test "$enableval" = no; then
 	      ac_enable_http1=no
-	  else	      
+	  else
 	      ac_enable_http1=yes
           fi
         ],
@@ -289,13 +289,13 @@ elif test "x${with_restconf}" = xnative; then
    if test "$ac_enable_http1" = "yes"; then
       AC_DEFINE(HAVE_HTTP1, true, [Set to true to enable Native HTTP/1]) # Must be tree/false (not 0/1) used in shells
       HAVE_HTTP1=true
-   fi	
+   fi
 
    # Check if nghttp2 is enabled for http/2
    AC_ARG_ENABLE(nghttp2, AS_HELP_STRING([--disable-nghttp2],[Disable nghttp2 for native restconf http/2, ie http/1 only]),[
 	  if test "$enableval" = no; then
 	      ac_enable_nghttp2=no
-	  else	      
+	  else
 	      ac_enable_nghttp2=yes
           fi
         ],
@@ -304,12 +304,12 @@ elif test "x${with_restconf}" = xnative; then
    if test "$ac_enable_nghttp2" = "yes"; then
       AC_CHECK_HEADERS(nghttp2/nghttp2.h,[], AC_MSG_ERROR([nghttp2 missing]))
       AC_CHECK_LIB(nghttp2, nghttp2_session_server_new,, AC_MSG_ERROR([nghttp2 missing]))
-      HAVE_LIBNGHTTP2=true 
-   fi    
+      HAVE_LIBNGHTTP2=true
+   fi
    AC_DEFINE(WITH_RESTCONF_NATIVE, 1, [Use native restconf mode]) # For c-code that cant use strings
 elif test "x${with_restconf}" = xno; then
    # Cant get around "no" as an answer for --without-restconf that is reset here to undefined
-   with_restconf=   
+   with_restconf=
 else
    AC_MSG_ERROR([No such restconf package: ${with_restconf}])
 fi
@@ -328,7 +328,7 @@ AC_ARG_WITH([restconf],
 AC_ARG_ENABLE(netsnmp, AS_HELP_STRING([--enable-netsnmp],[Enable net-snmp Clixon YANG mapping]),[
    if test "$enableval" = no; then
       enable_netsnmp=no
-   else	      
+   else
       enable_netsnmp=yes
    fi
   ],
@@ -339,7 +339,7 @@ if test "$enable_netsnmp" = "yes"; then
    # All libs are:
    # libnetsnmp, libnetsnmpagent, libnetsnmpmibs, libnetsnmptrapd, libnetsnmphelpers
    AC_CHECK_LIB(netsnmp, init_snmp)
-   AC_CHECK_LIB(netsnmpagent, init_agent)	
+   AC_CHECK_LIB(netsnmpagent, init_agent)
    AC_CHECK_HEADERS(net-snmp/net-snmp-config.h,[], AC_MSG_ERROR([snmp is missing]))
 
    # MIB_GENERATED_YANG_DIR is where clixon assumes generated YANGs from MIBs are stored
@@ -352,7 +352,7 @@ if test "$enable_netsnmp" = "yes"; then
       [MIB_GENERATED_YANG_DIR="${prefix}/share/mib-yangs"]
     )
     AC_MSG_RESULT(Generated YANGs from MIB files are expected to be in ${MIB_GENERATED_YANG_DIR})
-fi 
+fi
 
 # Set default config file location
 CLIXON_DEFAULT_CONFIG=/usr/local/etc/clixon.xml
@@ -372,8 +372,8 @@ AC_CHECK_LIB(socket, socket)
 AC_CHECK_LIB(dl, dlopen)
 
 # This is for digest / restconf
-AC_CHECK_LIB(ssl, OPENSSL_init_ssl ,, AC_MSG_ERROR([libssl missing]))
 AC_CHECK_LIB(crypto, CRYPTO_new_ex_data, , AC_MSG_ERROR([libcrypto missing]))
+AC_CHECK_LIB(ssl, OPENSSL_init_ssl ,, AC_MSG_ERROR([libssl missing]))
 
 # This is for libxml2 XSD regex engine
 # Note this only enables the compiling of the code. In order to actually
@@ -391,7 +391,7 @@ if test "${with_libxml2}"; then
       LIBXML2_CFLAGS="-I/usr/include/libxml2"
    fi
    AC_CHECK_LIB(xml2, xmlRegexpCompile,[], AC_MSG_ERROR([libxml2 not found]))
-fi 
+fi
 
 #
 AC_CHECK_FUNCS(inet_aton sigvec strlcpy strsep strndup alphasort versionsort getpeereid setns getresuid)
@@ -406,7 +406,7 @@ AC_ARG_WITH(
 
 if test "x${with_sigaction}" = "xyes"; then
    AC_CHECK_FUNCS(sigaction)
-fi 
+fi
 
 # Checks for getsockopt options for getting unix socket peer credentials on
 # Linux
@@ -420,9 +420,9 @@ AC_MSG_RESULT(Have getsockopt SO_PEERCRED)],[])
 AC_ARG_WITH(yang-installdir,
             [AS_HELP_STRING([--with-yang-installdir=DIR],[Install Clixon yang files here (default: ${prefix}/share/clixon)])],
 	    [YANG_INSTALLDIR="$withval"],
-    	    [YANG_INSTALLDIR="${prefix}/share/clixon"]		
+    	    [YANG_INSTALLDIR="${prefix}/share/clixon"]
 	    )
-AC_MSG_RESULT(Clixon yang files are installed in ${YANG_INSTALLDIR})	
+AC_MSG_RESULT(Clixon yang files are installed in ${YANG_INSTALLDIR})
 
 # YANG_STANDARD_DIR is where clixon assumes standard IETF are
 # This is NOT installed by Clixon and is not needed for core system
@@ -431,9 +431,9 @@ AC_MSG_RESULT(Clixon yang files are installed in ${YANG_INSTALLDIR})
 AC_ARG_WITH(yang-standard-dir,
             [AS_HELP_STRING([--with-yang-standard-dir=DIR],[Directory of standard IETF/IEEE YANG specs (default: $prefix/share/yang/standard)])],
 	    [YANG_STANDARD_DIR="$withval"],
-    	    [YANG_STANDARD_DIR="${prefix}/share/yang/standard"]		
+    	    [YANG_STANDARD_DIR="${prefix}/share/yang/standard"]
 	    )
-AC_MSG_RESULT(Standard YANG files expected to be in ${YANG_STANDARD_DIR})	
+AC_MSG_RESULT(Standard YANG files expected to be in ${YANG_STANDARD_DIR})
 
 # who we run as in our examples and tests
 CLICON_USER="clicon"
@@ -463,11 +463,11 @@ test "x$prefix" = xNONE && prefix=$ac_default_prefix
 
 AC_CONFIG_FILES([Makefile
 	  lib/Makefile
-	  lib/src/Makefile 
-	  lib/clixon/Makefile 
-	  apps/Makefile 
-	  apps/cli/Makefile 
-	  apps/backend/Makefile 
+	  lib/src/Makefile
+	  lib/clixon/Makefile
+	  apps/Makefile
+	  apps/cli/Makefile
+	  apps/backend/Makefile
 	  apps/netconf/Makefile
 	  apps/restconf/Makefile
   	  apps/snmp/Makefile
@@ -479,7 +479,7 @@ AC_CONFIG_FILES([Makefile
     	  example/main/example.xml
 	  docker/Makefile
     	  docker/clixon-dev/Makefile
-    	  docker/example/Makefile	  
+    	  docker/example/Makefile
   	  docker/test/Makefile
 	  yang/Makefile
   	  yang/clixon/Makefile
@@ -488,6 +488,6 @@ AC_CONFIG_FILES([Makefile
 	  test/Makefile
   	  test/config.sh
 	  test/cicd/Makefile
-  	  test/vagrant/Makefile	
+  	  test/vagrant/Makefile
 ])
 AC_OUTPUT


### PR DESCRIPTION
Our crosscompile build / configure task failed because of the openssl check. The reason is that libssl was tested before libcrypto. Without libcrypto, however, libssl cannot be built, which is why the configure task fails. This pull request changes the order in the configure file.

(It also removes all trailing spaces. Due to the previous pull request findings, I have changed my IDE settings so that these are now always removed.)