### PR TITLE
add revert failed cb

### DIFF
--- a/apps/backend/backend_plugin.c
+++ b/apps/backend/backend_plugin.c
@@ -807,16 +807,16 @@ plugin_transaction_revert_all(clixon_handle       h,
 }
 
 /*! Revert a commit for failed plugin
- * The revert failed is called for only failed plugin before revert all cb.
+ * The commit failed is called for only failed plugin before revert all cb.
  */
 static int
-plugin_transaction_revert_failed(clixon_plugin_t      *cp,
+plugin_transaction_commit_failed(clixon_plugin_t      *cp,
                                 clixon_handle       h,
                                 transaction_data_t *td)
 {
     trans_cb_t *fn;
 
-    if ((fn = clixon_plugin_api_get(cp)->ca_trans_revert_failed) != NULL)
+    if ((fn = clixon_plugin_api_get(cp)->ca_trans_commit_failed) != NULL)
         return plugin_transaction_call_one(h, cp, fn, __FUNCTION__, td);
     return 0;
 }
@@ -862,8 +862,8 @@ plugin_transaction_commit_all(clixon_handle       h,
     while ((cp = clixon_plugin_each(h, cp)) != NULL) {
         i++;
         if (plugin_transaction_commit_one(cp, h, td) < 0){
-            /*First make an effort ro revert transaction for the failed plugin*/
-            plugin_transaction_revert_failed(cp, h, td);
+            /* First make an effort ro revert transaction for the failed plugin */
+            plugin_transaction_commit_failed(cp, h, td);
             /* Make an effort to revert transaction */
             plugin_transaction_revert_all(h, td, i-1);
             goto done;

--- a/apps/backend/backend_plugin.c
+++ b/apps/backend/backend_plugin.c
@@ -806,6 +806,20 @@ plugin_transaction_revert_all(clixon_handle       h,
     return retval; /* ignore errors */
 }
 
+/*! Revert a commit for failed plugin
+ * The revert failed is called for only failed plugin before revert all cb.
+ */
+static int
+plugin_transaction_revert_failed(clixon_plugin_t      *cp,
+                                clixon_handle       h,
+                                transaction_data_t *td)
+{
+    trans_cb_t *fn;
+
+    if ((fn = clixon_plugin_api_get(cp)->ca_trans_revert_failed) != NULL)
+        return plugin_transaction_call_one(h, cp, fn, __FUNCTION__, td);
+    return 0;
+}
 
 /*! Call single plugin transaction_commit() in a commit transaction
  *
@@ -848,6 +862,8 @@ plugin_transaction_commit_all(clixon_handle       h,
     while ((cp = clixon_plugin_each(h, cp)) != NULL) {
         i++;
         if (plugin_transaction_commit_one(cp, h, td) < 0){
+            /*First make an effort ro revert transaction for the failed plugin*/
+            plugin_transaction_revert_failed(cp, h, td);
             /* Make an effort to revert transaction */
             plugin_transaction_revert_all(h, td, i-1);
             goto done;

--- a/lib/clixon/clixon_plugin.h
+++ b/lib/clixon/clixon_plugin.h
@@ -402,7 +402,7 @@ struct clixon_plugin_api{
             trans_cb_t       *cb_trans_complete; /* Transaction validation complete */
             trans_cb_t       *cb_trans_commit;   /* Transaction commit */
             trans_cb_t       *cb_trans_commit_done; /* Transaction when commit done */
-            trans_cb_t       *cb_trans_commit_failed;   /* Transaction revert failed*/
+            trans_cb_t       *cb_trans_commit_failed;   /* Transaction commit failed*/
             trans_cb_t       *cb_trans_revert;   /* Transaction revert */
             trans_cb_t       *cb_trans_end;      /* Transaction completed  */
             trans_cb_t       *cb_trans_abort;    /* Transaction aborted */

--- a/lib/clixon/clixon_plugin.h
+++ b/lib/clixon/clixon_plugin.h
@@ -402,7 +402,7 @@ struct clixon_plugin_api{
             trans_cb_t       *cb_trans_complete; /* Transaction validation complete */
             trans_cb_t       *cb_trans_commit;   /* Transaction commit */
             trans_cb_t       *cb_trans_commit_done; /* Transaction when commit done */
-            trans_cb_t       *cb_trans_revert_failed;   /* Transaction revert failed*/
+            trans_cb_t       *cb_trans_commit_failed;   /* Transaction revert failed*/
             trans_cb_t       *cb_trans_revert;   /* Transaction revert */
             trans_cb_t       *cb_trans_end;      /* Transaction completed  */
             trans_cb_t       *cb_trans_abort;    /* Transaction aborted */
@@ -425,7 +425,7 @@ struct clixon_plugin_api{
 #define ca_trans_complete u.cau_backend.cb_trans_complete
 #define ca_trans_commit   u.cau_backend.cb_trans_commit
 #define ca_trans_commit_done u.cau_backend.cb_trans_commit_done
-#define ca_trans_revert_failed   u.cau_backend.cb_trans_revert_failed
+#define ca_trans_commit_failed   u.cau_backend.cb_trans_commit_failed
 #define ca_trans_revert   u.cau_backend.cb_trans_revert
 #define ca_trans_end      u.cau_backend.cb_trans_end
 #define ca_trans_abort    u.cau_backend.cb_trans_abort

--- a/lib/clixon/clixon_plugin.h
+++ b/lib/clixon/clixon_plugin.h
@@ -402,6 +402,7 @@ struct clixon_plugin_api{
             trans_cb_t       *cb_trans_complete; /* Transaction validation complete */
             trans_cb_t       *cb_trans_commit;   /* Transaction commit */
             trans_cb_t       *cb_trans_commit_done; /* Transaction when commit done */
+            trans_cb_t       *cb_trans_revert_failed;   /* Transaction revert failed*/
             trans_cb_t       *cb_trans_revert;   /* Transaction revert */
             trans_cb_t       *cb_trans_end;      /* Transaction completed  */
             trans_cb_t       *cb_trans_abort;    /* Transaction aborted */
@@ -424,6 +425,7 @@ struct clixon_plugin_api{
 #define ca_trans_complete u.cau_backend.cb_trans_complete
 #define ca_trans_commit   u.cau_backend.cb_trans_commit
 #define ca_trans_commit_done u.cau_backend.cb_trans_commit_done
+#define ca_trans_revert_failed   u.cau_backend.cb_trans_revert_failed
 #define ca_trans_revert   u.cau_backend.cb_trans_revert
 #define ca_trans_end      u.cau_backend.cb_trans_end
 #define ca_trans_abort    u.cau_backend.cb_trans_abort


### PR DESCRIPTION
Hello @olofhagsand 
Following this conversation https://github.com/clicon/clixon/issues/517

Could you pls check if it possible to merge this PR?

Current callback order:
```
Aug 30 05:33:04.906929: Plugin 01: BEGIN
Aug 30 05:33:04.906944: Plugin 02: BEGIN
Aug 30 05:33:04.906947: Plugin 03: BEGIN
Aug 30 05:33:04.906950: Plugin 04: BEGIN
Aug 30 05:33:04.906969: Plugin 01: VALIDATE
Aug 30 05:33:04.906972: Plugin 02: VALIDATE
Aug 30 05:33:04.906974: Plugin 03: VALIDATE
Aug 30 05:33:04.906977: Plugin 04: VALIDATE
Aug 30 05:33:04.906980: Plugin 01: COMPLETE
Aug 30 05:33:04.906982: Plugin 02: COMPLETE
Aug 30 05:33:04.906984: Plugin 03: COMPLETE
Aug 30 05:33:04.906986: Plugin 04: COMPLETE
Aug 30 05:33:04.906995: Plugin 01: COMMIT
Aug 30 05:33:04.906998: Plugin 02: COMMIT
Aug 30 05:33:04.907000: Plugin 03: COMMIT
Aug 30 05:33:04.907002: Plugin 04: COMMIT FAILED
Aug 30 05:33:04.907009: Plugin 04: REVERT FAILED
Aug 30 05:33:04.907012: Plugin 03: REVERT
Aug 30 05:33:04.907014: Plugin 02: REVERT
Aug 30 05:33:04.907016: Plugin 01: REVERT
Aug 30 05:33:04.907019: Plugin 01: ABORT
Aug 30 05:33:04.907022: Plugin 02: ABORT
Aug 30 05:33:04.907024: Plugin 03: ABORT
Aug 30 05:33:04.907026: Plugin 04: ABORT
```