### PR TITLE
Add username when reading and subscribing streams

### DIFF
--- a/apps/snmp/snmp_stream.c
+++ b/apps/snmp/snmp_stream.c
@@ -333,8 +333,12 @@ snmp_stream_subscribe(clixon_handle  h,
         clixon_err(OE_SNMP, errno, "cbuf_new");
         goto done;
     }
-    cprintf(cb, "<rpc xmlns=\"%s\" %s><create-subscription xmlns=\"%s\"><stream>%s</stream>",
-            NETCONF_BASE_NAMESPACE, NETCONF_MESSAGE_ID_ATTR, EVENT_RFC5277_NAMESPACE, stream);
+    cprintf(cb, "<rpc xmlns=\"%s\" username=\"%s\" %s><create-subscription xmlns=\"%s\"><stream>%s</stream>",
+            NETCONF_BASE_NAMESPACE,
+            clicon_username_get(h),
+            NETCONF_MESSAGE_ID_ATTR,
+            EVENT_RFC5277_NAMESPACE,
+            stream);
     cprintf(cb, "</create-subscription></rpc>]]>]]>");
     if (clicon_rpc_netconf(h, cbuf_get(cb), &xret, &s) < 0)
         goto done;
@@ -396,9 +400,13 @@ get_all_streams_from_backend(clixon_handle    h,
         clixon_err(OE_SNMP, errno, "cbuf_new");
         goto done;
     }
-    /* get alle streams from backend */
-    cprintf(cb, "<rpc xmlns=\"%s\" %s><get><filter type=\"subtree\"><netconf xmlns=\"%s\"><streams/></netconf></filter></get></rpc>]]>]]>",
-            NETCONF_BASE_NAMESPACE, NETCONF_MESSAGE_ID_ATTR, EVENT_RFC5277_NAMESPACE);
+    /* get all streams from backend */
+    cprintf(cb, "<rpc xmlns=\"%s\" username=\"%s\" %s><get><filter type=\"subtree\">"
+            "<netconf xmlns=\"%s\"><streams/></netconf></filter></get></rpc>]]>]]>",
+            NETCONF_BASE_NAMESPACE,
+            clicon_username_get(h),
+            NETCONF_MESSAGE_ID_ATTR,
+            EVENT_RFC5277_NAMESPACE);
     if (clicon_rpc_netconf(h, cbuf_get(cb), &xret, NULL) < 0)
         goto done;
     if ((xe = xpath_first(xret, NULL, "rpc-reply/rpc-error")) != NULL)


### PR DESCRIPTION
With activated NACM the snmp subagent is not able to read and subscribe the streams. With this pull-request we add the username to the internal netconf request between the snmp subagent and clixon backend