### PR TITLE
Add a way to report rpc-errors from a plugin

### DIFF
--- a/apps/backend/backend_client.c
+++ b/apps/backend/backend_client.c
@@ -723,7 +723,7 @@ from_client_edit_config(clixon_handle h,
             }
         }
         if ((ret = candidate_commit(h, NULL, "candidate", myid, 0, cbret)) < 0){ /* Assume validation fail, nofatal */
-            if (netconf_operation_failed(cbret, "application", clixon_err_reason())< 0)
+            if (clixon_plugin_report_err(h, cbret) < 0)
                 goto done;
             xmldb_copy(h, "running", "candidate");
             goto ok;

--- a/apps/backend/backend_commit.c
+++ b/apps/backend/backend_commit.c
@@ -638,7 +638,7 @@ candidate_validate(clixon_handle h,
          * TODO: -1 return should be fatal error, not failed validation
          */
         if (!cbuf_len(cbret) &&
-            netconf_operation_failed(cbret, "application", clixon_err_reason())< 0)
+            clixon_plugin_report_err(h, cbret) < 0)
             goto done;
         goto fail;
     }
@@ -858,7 +858,7 @@ from_client_commit(clixon_handle h,
     if ((ret = candidate_commit(h, xe, "candidate", myid, 0, cbret)) < 0){ /* Assume validation fail, nofatal */
         clixon_debug(CLIXON_DBG_BACKEND, "Commit candidate failed");
         if (ret < 0)
-            if (netconf_operation_failed(cbret, "application", clixon_err_reason())< 0)
+            if (clixon_plugin_report_err(h, cbret) < 0)
                 goto done;
         goto ok;
     }

--- a/apps/backend/backend_plugin.c
+++ b/apps/backend/backend_plugin.c
@@ -295,7 +295,7 @@ clixon_plugin_statedata_one(clixon_plugin_t *cp,
         if (fn(h, nsc, xpath, x) < 0){
             if (clixon_resource_check(h, &wh, clixon_plugin_name_get(cp), __FUNCTION__) < 0)
                 goto done;
-            if (clixon_err_category() < 0)
+            if (clixon_err_category() < 0 && !clixon_plugin_rpc_err_set(h))
                 clixon_log(h, LOG_WARNING, "%s: Internal error: State callback in plugin: %s returned -1 but did not make a clixon_err call",
                            __FUNCTION__, clixon_plugin_name_get(cp));
             goto fail;  /* Dont quit here on user callbacks */
@@ -342,7 +342,6 @@ clixon_plugin_statedata_all(clixon_handle   h,
     int              ret;
     cxobj           *x = NULL;
     clixon_plugin_t *cp = NULL;
-    cbuf            *cberr = NULL;
     cxobj           *xerr = NULL;
 
     clixon_debug(CLIXON_DBG_BACKEND | CLIXON_DBG_DETAIL, "");
@@ -350,14 +349,10 @@ clixon_plugin_statedata_all(clixon_handle   h,
         if ((ret = clixon_plugin_statedata_one(cp, h, nsc, xpath, &x)) < 0)
             goto done;
         if (ret == 0){
-            if ((cberr = cbuf_new()) == NULL){
-                clixon_err(OE_UNIX, errno, "cbuf_new");
-                goto done;
-            }
             /* error reason should be in clixon_err_reason */
-            cprintf(cberr, "Internal error, state callback in plugin %s returned invalid XML: %s",
-                    clixon_plugin_name_get(cp), clixon_err_reason());
-            if (netconf_operation_failed_xml(&xerr, "application", cbuf_get(cberr)) < 0)
+            if (clixon_plugin_report_err_xml(h, &xerr,
+                                             "Internal error, state callback in plugin %s returned invalid XML: %s",
+                                             clixon_plugin_name_get(cp), clixon_err_reason()) < 0)
                 goto done;
             xml_free(*xret);
             *xret = xerr;
@@ -406,8 +401,6 @@ clixon_plugin_statedata_all(clixon_handle   h,
  done:
     if (xerr)
         xml_free(xerr);
-    if (cberr)
-        cbuf_free(cberr);
     if (x)
         xml_free(x);
     return retval;
@@ -589,8 +582,9 @@ plugin_transaction_call_one(clixon_handle       h,
     if (clixon_resource_check(h, &wh, clixon_plugin_name_get(cp), fnname) < 0)
         goto done;
     if (rv < 0) {
-        if (!clixon_err_category()) /* sanity: log if clixon_err() is not called ! */
-            clixon_log(h, LOG_NOTICE, "%s: Plugin '%s' callback does not make clixon_err call on error",
+        if (!clixon_plugin_rpc_err_set(h) && !clixon_err_category())
+            /* sanity: log if err is not called ! */
+            clixon_log(h, LOG_NOTICE, "%s: Plugin '%s' callback does not make clixon_err or clixon_plugin_rpc_err call on error",
                        fnname, clixon_plugin_name_get(cp));
         goto done;
     }

--- a/example/main/example_backend_nacm.c
+++ b/example/main/example_backend_nacm.c
@@ -100,11 +100,19 @@ nacm_validate(clixon_handle    h,
     if (_transaction_log)
         transaction_log(h, td, LOG_NOTICE, __FUNCTION__);
     if (_validate_fail_xpath){
-        if (_validate_fail_toggle==0 &&
-            xpath_first(transaction_target(td), NULL, "%s", _validate_fail_xpath)){
-            _validate_fail_toggle = 1; /* toggle if triggered */
-            clixon_err(OE_XML, 0, "User error");
-            return -1; /* induce fail */
+        if (xpath_first(transaction_target(td), NULL, "%s", _validate_fail_xpath)) {
+            if (_validate_fail_toggle==0) {
+                _validate_fail_toggle = 1; /* toggle if triggered */
+                clixon_err(OE_XML, 0, "User error");
+                return -1; /* induce fail */
+            } else if (_validate_fail_toggle==2) {
+                _validate_fail_toggle = 0; /* toggle if triggered */
+                clixon_plugin_rpc_err(h, NULL,
+                                      "application", "test_error_tag",
+                                      "test_error_info", "error",
+                                      "test_error_data %d", 1234);
+                return -1; /* induce fail */
+            }
         }
     }
     return 0;
@@ -130,7 +138,7 @@ nacm_commit(clixon_handle    h,
     if (_validate_fail_xpath){
         if (_validate_fail_toggle==1 &&
             xpath_first(transaction_target(td), NULL, "%s", _validate_fail_xpath)){
-            _validate_fail_toggle = 0; /* toggle if triggered */
+            _validate_fail_toggle = 2; /* toggle if triggered */
             clixon_err(OE_XML, 0, "User error");
             return -1; /* induce fail */
         }

--- a/lib/clixon/clixon_netconf_lib.h
+++ b/lib/clixon/clixon_netconf_lib.h
@@ -161,6 +161,11 @@ int netconf_missing_attribute_xml(cxobj **xret, char *type, char *info, char *me
 int netconf_bad_attribute(cbuf *cb, char *type, char *info, char *message);
 int netconf_bad_attribute_xml(cxobj **xret, char *type, char *info, char *message);
 int netconf_unknown_attribute(cbuf *cb, char *type, char *info, char *message);
+int netconf_common_rpc_err(cbuf *cb, char *ns, char *type, char *tag, char *info,
+                           char *severity, char *message);
+int netconf_common_rpc_err_xml(cxobj **xret, char *ns, char *type, char *tag,
+                               char *severity, char *infotag, char *info,
+                               char *message);
 int netconf_missing_element(cbuf *cb, char *type, char *element, char *message);
 int netconf_missing_yang_xml(cxobj **xret, char *path, char *app_tag, char *info, char *message);
 int netconf_missing_element_xml(cxobj **xret, char *type, char *element, char *message);

--- a/lib/clixon/clixon_plugin.h
+++ b/lib/clixon/clixon_plugin.h
@@ -552,4 +552,11 @@ const char *clixon_auth_type_int2str(clixon_auth_type_t auth_type);
 int              clixon_plugin_module_init(clixon_handle h);
 int              clixon_plugin_module_exit(clixon_handle h);
 
+int clixon_plugin_rpc_err(clixon_handle h, const char *ns,
+                          const char *type, const char *tag, const char *info,
+                          const char *severity, const char *fmt, ...);
+int clixon_plugin_rpc_err_set(clixon_handle h);
+int clixon_plugin_report_err(clixon_handle h, cbuf *cbret);
+int clixon_plugin_report_err_xml(clixon_handle h, cxobj **xreg, char *err, ...);
+
 #endif  /* _CLIXON_PLUGIN_H_ */

--- a/lib/src/clixon_plugin.c
+++ b/lib/src/clixon_plugin.c
@@ -77,6 +77,7 @@
 #include "clixon_netconf_lib.h"
 #include "clixon_validate.h"
 #include "clixon_proc.h"
+#include "clixon_data.h"
 #include "clixon_plugin.h"
 
 /*
@@ -1768,6 +1769,207 @@ clixon_auth_type_int2str(clixon_auth_type_t auth_type)
     return clicon_int2str(clixon_auth_type, auth_type);
 }
 
+/*! Save an RPC error to be reported by clixon.
+ *
+ * @param[in]  h        Clixon
+ * @param[in]  ns       Namespace.  If NULL the netconf base ns will be used
+ * @param[in]  type     Error type: "rpc", "application" or "protocol"
+ * @param[in]  severity Severity: "error" or "warning"
+ * @param[in]  tag      Error tag, like "invalid-value" or "unknown-attribute"
+ * @param[in]  info     bad-attribute or bad-element xml.  If NULL not included.
+ * @param[in]  fmt      Error message format.  May be NULL.
+ * @retval     0        Success
+ * @retval    -1        Error
+ */
+int
+clixon_plugin_rpc_err(clixon_handle h,
+                      const char *ns,
+                      const char *type,
+                      const char *tag,
+                      const char *info,
+                      const char *severity,
+                      const char *fmt, ...)
+{
+    int retval = -1;
+    int err;
+    cvec *cvv = NULL;
+    cvec *old_cvv = clicon_data_cvec_get(h, "rpc_err");
+
+    cvv = cvec_new(0);
+    if (!cvv)
+        goto done;
+    if (ns) {
+        if (cvec_add_string(cvv, "ns", ns))
+            goto done;
+    }
+    if (cvec_add_string(cvv, "type", type))
+        goto done;
+    if (cvec_add_string(cvv, "tag", tag))
+        goto done;
+    if (info) {
+        if (cvec_add_string(cvv, "info", info))
+            goto done;
+    }
+    if (cvec_add_string(cvv, "severity", severity))
+        goto done;
+    if (fmt) {
+        va_list args;
+        cbuf *cb;
+
+        cb = cbuf_new();
+        if (!cb)
+            goto done;
+        va_start(args, fmt);
+        err = vcprintf(cb, fmt, args);
+        va_end(args);
+        if (err < 0) {
+            cbuf_free(cb);
+            goto done;
+        }
+        cvec_add_string(cvv, "message", cbuf_get(cb));
+        cbuf_free(cb);
+    }
+
+    err = clicon_data_cvec_set(h, "rpc_err", cvv);
+    if (err)
+        goto done;
+
+    retval = 0;
+
+ done:
+    if (retval && cvv)
+        cvec_free(cvv);
+    if (!retval && old_cvv)
+        cvec_free(old_cvv);
+    return retval;
+}
+
+/*! Frees memory associated with clixon_rpc_err().
+ *
+ * @param[in]  h        Clixon
+ */
+static void
+clixon_plugin_rpc_err_exit(clixon_handle h)
+{
+    cvec *cvv = clicon_data_cvec_get(h, "rpc_err");
+
+    clicon_ptr_del(h, "rpc_err");
+    cvec_free(cvv);
+}
+
+/*! Returns if the rpc error has already been set.
+ *
+ * @param[in]  h        Clixon
+ *
+ * @retval     0        The rpc error is not set
+ * @retval     1        The rpc error is set
+ */
+int
+clixon_plugin_rpc_err_set(clixon_handle h)
+{
+    return clicon_data_cvec_get(h, "rpc_err") != NULL;
+}
+
+static int
+netconf_gen_rpc_err(clixon_handle h, cbuf *cbret)
+{
+    cvec *cvv = clicon_data_cvec_get(h, "rpc_err");
+    int retval;
+
+    /* Delete the pointer so the cvec doesn't get freed. */
+    clicon_ptr_del(h, "rpc_err");
+    retval = netconf_common_rpc_err(cbret,
+                                    cvec_find_str(cvv, "ns"),
+                                    cvec_find_str(cvv, "type"),
+                                    cvec_find_str(cvv, "tag"),
+                                    cvec_find_str(cvv, "severity"),
+                                    cvec_find_str(cvv, "info"),
+                                    cvec_find_str(cvv, "message"));
+    cvec_free(cvv);
+
+    return retval;
+}
+
+static int
+netconf_gen_rpc_err_xml(clixon_handle h, cxobj **xret)
+{
+    cvec *cvv = clicon_data_cvec_get(h, "rpc_err");
+    int retval;
+
+    /* Delete the pointer so the cvec doesn't get freed. */
+    clicon_ptr_del(h, "rpc_err");
+    retval = netconf_common_rpc_err_xml(xret,
+                                        cvec_find_str(cvv, "ns"),
+                                        cvec_find_str(cvv, "type"),
+                                        cvec_find_str(cvv, "tag"),
+                                        cvec_find_str(cvv, "severity"),
+                                        NULL,
+                                        cvec_find_str(cvv, "info"),
+                                        cvec_find_str(cvv, "message"));
+    cvec_free(cvv);
+
+    return retval;
+}
+
+/*! Report an error from a plugin.
+ *
+ * @param[in]  h      Clixon
+ * @param[out] cbret  CLIgen buffer w error stmt if retval = 0
+ * @retval     0      Success
+ * @retval    -1      Error
+ */
+int
+clixon_plugin_report_err(clixon_handle h,
+                         cbuf *cbret)
+{
+    int ret;
+
+    if (clixon_plugin_rpc_err_set(h)) {
+        if ((ret = netconf_gen_rpc_err(h, cbret)) < 0)
+            return ret;
+    } else if ((ret = netconf_operation_failed(cbret, "application",
+                                               clixon_err_reason())) < 0) {
+        return ret;
+    }
+
+    return 0;
+}
+
+/*! Report an error from a plugin.
+ *
+ * @param[in]  h     Clixon
+ * @param[out] xret  Error XML tree. Free with xml_free after use
+ * @retval     0     Success
+ * @retval    -1     Error
+ */
+int
+clixon_plugin_report_err_xml(clixon_handle h,
+                             cxobj **xret,
+                             char *err,
+                             ...)
+{
+    int ret = -1;
+    cbuf *cberr;
+    va_list ap;
+
+    if (clixon_plugin_rpc_err_set(h)) {
+        ret = netconf_gen_rpc_err_xml(h, xret);
+    } else {
+        if ((cberr = cbuf_new()) == NULL) {
+            clixon_err(OE_UNIX, errno, "cbuf_new");
+            goto done;
+        }
+        va_start(ap, err);
+        vcprintf(cberr, err, ap);
+        ret = netconf_operation_failed_xml(xret, "application",
+                                           cbuf_get(cberr));
+        cbuf_free(cberr);
+    }
+
+done:
+    return ret;
+}
+
 /*! Initialize plugin module by creating a handle holding plugin and callback lists
  *
  * This should be called once at start by every application
@@ -1819,5 +2021,7 @@ clixon_plugin_module_exit(clixon_handle h)
         free(ph);
         plugin_module_struct_set(h, NULL);
     }
+    /* Free memory associated with plugin_rpc_err() */
+    clixon_plugin_rpc_err_exit(h);
     return 0;
 }


### PR DESCRIPTION
Add plugin_rpc_err(), which works something like clixon_err, but it saves error information from a plugin for reporting rpc-errors that need to be returned.

This is an RFC, would this be ok?