### PR TITLE
Fix valgrind error upon closelog() when using musl libc

### DIFF
--- a/lib/src/clixon_log.c
+++ b/lib/src/clixon_log.c
@@ -160,7 +160,11 @@ clixon_log_init(clixon_handle h,
             /* Cant syslog here */
             fprintf(stderr, "%s: setlogmask: %s\n", __FUNCTION__, strerror(errno));
         _log_openlog = 1;
-        openlog(ident, LOG_PID, LOG_USER); /* LOG_PUSER is achieved by direct stderr logs in clixon_log */
+        /* LOG_PUSER is achieved by direct stderr logs in clixon_log.
+         * In musl libc, closelog() may cause "Invalid file descriptor" error
+         * which is seen by valgrind unless LOG_NDELAY option is provided.
+         */
+        openlog(ident, LOG_PID | LOG_NDELAY, LOG_USER);
     }
     return 0;
 }


### PR DESCRIPTION
In musl libc, valgrind may detect an "Invalid file descriptor" error upon `closelog()` call if the previous `openlog()` call was not passed the `LOG_NDELAY` option and `syslog()` wasn't called afterwards.

musl libc has an issue in this file: https://git.musl-libc.org/cgit/musl/tree/src/misc/syslog.c?id=c47ad25ea3b484e10326f933e927c0bc8cded3da

Namely, in `openlog()`, `__openlog()` which sets `log_fd` is not called immediately if `LOG_NDELAY` option is not used. In this case, `log_fd` is only set upon next `syslog()` call. `closelog()` does not check if `log_fd == 1` and just tries to close `log_fd`, causing `Invalid file descriptor` error which is shown by valgrind.

In my environment, this was causing mem tests to fail in `test_confirmed_commit.sh` with the following diagnostics:
```
==6971== File descriptor -1 Invalid file descriptor
==6971==    at 0x4065D10: __syscall_cp_c (pthread_cancel.c:38)
==6971==    by 0x4069C00: close (close.c:16)
==6971==    by 0x405629B: closelog (syslog.c:46)
==6971==    by 0x48F8A44: clixon_log_exit (clixon_log.c:176)
==6971==    by 0x1111FB: backend_terminate.isra.0 (backend_main.c:140)
==6971==    by 0x10F636: main (backend_main.c:1112)
```

An alternative fix would be to only call `closelog()` if `syslog()` was called, but this might be problematic if `syslog()` is somehow called from a location other than `clixon_log_str()` (e.g. from some library call).