### PR TITLE
stream: removing all opened sockets for a stream

### DIFF
--- a/lib/clixon/clixon_stream.h
+++ b/lib/clixon/clixon_stream.h
@@ -99,6 +99,7 @@ struct stream_subscription *stream_ss_add(clixon_handle h, char *stream,
                   char *xpath, struct timeval *start, struct timeval *stop,
                   stream_fn_t fn, void *arg);
 int stream_ss_rm(clixon_handle h, event_stream_t *es, struct stream_subscription *ss, int force);
+int stream_ss_rm_all(clixon_handle h, char *stream);
 struct stream_subscription *stream_ss_find(event_stream_t *es,
                                            stream_fn_t fn, void *arg);
 int stream_ss_delete_all(clixon_handle h, stream_fn_t fn, void *arg);

--- a/lib/src/clixon_stream.c
+++ b/lib/src/clixon_stream.c
@@ -426,6 +426,36 @@ stream_ss_rm(clixon_handle               h,
     return 0;
 }
 
+/*! Delete all event stream subscriptions to a stream given a name of a stream
+ *
+ * @param[in]  h      Clixon handle
+ * @param[in]  stream Name of stream
+ * @retval     0      OK
+ * @retval    -1      Error
+ */
+int
+stream_ss_rm_all(clixon_handle h,
+                 char          *stream)
+{
+    int                        retval = -1;
+    event_stream_t             *es;
+    struct stream_subscription *ss;
+
+    if (stream == NULL)
+        goto done;
+    if ((es = stream_find(h, stream)) == NULL)
+        goto done;
+    /* Don't iterate over queue, because removing element move pointer to a next
+     * element
+     */
+    while (es->es_subscription) {
+        stream_ss_rm(h, es, es->es_subscription, 1 /* force */);
+    }
+    retval = 0;
+  done:
+    return retval;
+}
+
 /*! Find stream callback given callback function and its (unique) argument
  *
  * @param[in]  es   Pointer to event stream


### PR DESCRIPTION
Added function for server side with oppportunity to close all opened stream sockets using only name of a stream.