### PR TITLE
added send notify systemd

### DIFF
--- a/apps/backend/backend_main.c
+++ b/apps/backend/backend_main.c
@@ -62,6 +62,10 @@
 #include <netinet/in.h>
 #include <libgen.h>
 
+#ifdef SYSTEMD_NOTIFY
+#include <systemd/sd-daemon.h>
+#endif
+
 /* cligen */
 #include <cligen/cligen.h>
 
@@ -1045,6 +1049,13 @@ main(int    argc,
     if (netconf_monitoring_statistics_init(h) < 0)
         goto done;
     clixon_log(h, LOG_NOTICE, "%s: %u Started", __PROGRAM__, getpid());
+
+#ifdef SYSTEMD_NOTIFY
+    if (sd_notify(0, "READY=1") < 0) {
+        goto done;
+    }
+#endif
+
     if (clixon_event_loop(h) < 0)
         goto done;
  ok:

--- a/configure.ac
+++ b/configure.ac
@@ -464,6 +464,24 @@ AH_BOTTOM([#include <clixon_custom.h>])
 
 test "x$prefix" = xNONE && prefix=$ac_default_prefix
 
+AC_ARG_ENABLE([systemd-notify],
+  AS_HELP_STRING([--enable-systemd-notify], [Enable send notify systemd]),
+  [if test "$enable_systemd_notify" = "yes"; then
+      AC_DEFINE([SYSTEMD_NOTIFY], 1, [Enable systemd notify])
+
+      # Check for systemd headers and the libsystemd library
+      AC_CHECK_HEADERS([systemd/sd-daemon.h], [],
+          AC_MSG_ERROR([Missing systemd headers required for systemd notify.]))
+
+      # Check for the sd_notify function in the libsystemd library
+      AC_CHECK_LIB([systemd], [sd_notify], [],
+          AC_MSG_ERROR([Missing libsystemd library required for systemd notify.]))
+
+      # Append '-lsystemd' to LIBS preserving previous values
+      LIBS="$LIBS -lsystemd"
+  fi
+])
+
 AC_CONFIG_FILES([Makefile
 	  lib/Makefile
 	  lib/src/Makefile

--- a/lib/src/clixon_event.c
+++ b/lib/src/clixon_event.c
@@ -55,6 +55,10 @@
 #include <sys/types.h>
 #include <sys/time.h>
 
+#ifdef SYSTEMD_NOTIFY
+#include <systemd/sd-daemon.h>
+#endif
+
 #include <cligen/cligen.h>
 
 #include "clixon_queue.h"
@@ -561,6 +565,13 @@ clixon_event_loop(clixon_handle h)
         return clixon_event_select_loop(h);
     }
     while (clixon_exit_get() != 1) {
+
+#ifdef SYSTEMD_NOTIFY
+        if (sd_notify(0, "WATCHDOG=1") < 0) {
+            goto err;
+        }
+#endif
+
         nfds = _ee_prio_nr + _ee_nr;
         if (nfds > nfds_max){
             nfds_max = nfds;


### PR DESCRIPTION
@olofhagsand good day, added new functional, correct process sending notify systemd

now other services can understand when the backend is actually running.

example:
```
$ cat /usr/lib/systemd/system/clixon-backend.service
[Unit]
Description=Clixon backend API service

[Service]
Type=notify
User=roma
RestartSec=60
Restart=on-failure
ExecStart=clixon_backend -D 7 -F -f /usr/share/test/clixon/clixon-test.xml
StandardOutput=null
StandardError=null
TimeoutStartSec=45
WatchdogSec=5

[Install]
WantedBy=multi-user.target
```