### PR TITLE
Better handle size_t on 32bit system for cli_show

### DIFF
--- a/apps/cli/cli_show.c
+++ b/apps/cli/cli_show.c
@@ -2012,7 +2012,8 @@ cli_show_statistics(clixon_handle h,
     uint64_t    nr;
     uint64_t    tnr0;
     uint64_t    tnr = 0;
-    size_t      sz;
+    uint64_t    sz;
+    size_t      esz;
     size_t      tsz0;
     size_t      tsz = 0;
     yang_stmt  *ymounts;
@@ -2075,17 +2076,17 @@ cli_show_statistics(clixon_handle h,
             inext2 = 0;
             while ((yspec = yn_iter(ydomain, &inext2)) != NULL) {
                 name = yang_argument_get(yspec);
-                nr = 0; sz = 0;
-                if (yang_stats(yspec, 0, &nr, &sz) < 0)
+                nr = 0; esz = 0;
+                if (yang_stats(yspec, 0, &nr, &esz) < 0)
                     goto done;
                 tnr += nr;
-                tsz += sz;
+                tsz += esz;
                 if (detail) {
-                    cligen_output(stdout, "YANG-%s-%s-size: %" PRIu64 "\n", domain, name, sz);
+                    cligen_output(stdout, "YANG-%s-%s-size: %zu\n", domain, name, esz);
                     cligen_output(stdout, "YANG-%s-%s-nr: %" PRIu64 "\n", domain, name, nr);
                 }
                 else{
-                    translatenumber(sz, &u64, &unit);
+                    translatenumber(esz, &u64, &unit);
                     cprintf(cb, "%s/%s", domain, name);
                     cligen_output(stdout, "%-25s %" PRIu64 "%-10s\n", cbuf_get(cb), u64, unit);
                     cbuf_reset(cb);
@@ -2093,7 +2094,7 @@ cli_show_statistics(clixon_handle h,
             }
         }
         if (detail){
-            cligen_output(stdout, "YANG-total-size: %" PRIu64 "\n", tsz);
+            cligen_output(stdout, "YANG-total-size: %zu\n", tsz);
             cligen_output(stdout, "YANG-total-nr: %" PRIu64 "\n", tnr);
         }
         else {
@@ -2111,19 +2112,19 @@ cli_show_statistics(clixon_handle h,
         while ((ph = cligen_ph_each(cli_cligen(h), ph)) != NULL) {
             if ((pt = cligen_ph_parsetree_get(ph)) == NULL)
                 continue;
-            nr = 0; sz = 0;
-            pt_stats(pt, &nr, &sz);
+            nr = 0; esz = 0;
+            pt_stats(pt, &nr, &esz);
             tnr += nr;
-            tsz += sz;
+            tsz += esz;
             if (detail){
-                cligen_output(stdout, "CLIspec-%s-size: %" PRIu64 "\n", cligen_ph_name_get(ph), sz);
+                cligen_output(stdout, "CLIspec-%s-size: %zu\n", cligen_ph_name_get(ph), esz);
                 cligen_output(stdout, "CLIspec-%s-nr: %" PRIu64 "\n", cligen_ph_name_get(ph), nr);
             }
         }
         if (detail){
-            cligen_output(stdout, "CLIspec-total-size: %" PRIu64 "\n", tsz);
+            cligen_output(stdout, "CLIspec-total-size: %zu\n", tsz);
             cligen_output(stdout, "CLIspec-total-nr: %" PRIu64 "\n", tnr);
-            cligen_output(stdout, "Mem-Total-size: %" PRIu64 "\n", tsz0+tsz);
+            cligen_output(stdout, "Mem-Total-size: %zu\n", tsz0+tsz);
             cligen_output(stdout, "Mem-Total-nr: %" PRIu64 "\n", tnr0+tnr);
         }
         else {


### PR DESCRIPTION
Size_t have different size on 32bit system and it's normally 4 bytes instead of 8 bytes.

This cause compilation warning and also error for parse_uint64.

To better handle this, introduce a new variable to handle case where size_t can be used as is and change sz type to uint64_t to follow parse_uint64 requirement.

This also handle corner case where value might be cut after parsing a value of 4 bytes expected to be 8 bytes.

While at it also change the cligen_output to %zu where size_t type is used to further mute additional compilation warning.