### PR TITLE
Resolve imports in lexical scope and fix leafref/xpath resolution

### DIFF
--- a/lib/clixon/clixon_yang_module.h
+++ b/lib/clixon/clixon_yang_module.h
@@ -81,5 +81,8 @@ yang_stmt *yang_find_module_by_name(yang_stmt *yspec, const char *name);
 int        yang_metadata_annotation_check(cxobj *x, yang_stmt *ymod, int *ismeta);
 int        yang_metadata_init(clixon_handle h);
 int        yang_lib2yspec(clixon_handle h, cxobj *yanglib, const char *mntpnt, const char *domain, yang_stmt *yspec);
+int        yang_imports_foreach_scope(yang_stmt *ys, yang_stmt *yspec,
+                                      int (*cb)(yang_stmt *yimport, void *arg),
+                                      void *arg);
 
 #endif  /* _CLIXON_YANG_MODULE_H_ */

--- a/lib/src/clixon_xpath_yang.c
+++ b/lib/src/clixon_xpath_yang.c
@@ -171,7 +171,8 @@ xp_yang_eval_step(xp_yang_ctx  *xy0,
                     if ((ys1 = yang_find_module_by_prefix_yspec(ys, prefix)) != NULL)
                         ys = ys1;
                 }
-                else if (yang_keyword_get(ys) == Y_MODULE){ /* This means top */
+                else if (yang_keyword_get(ys) == Y_MODULE ||
+                         yang_keyword_get(ys) == Y_SUBMODULE) { /* This means top */
                     if ((ys1 = yang_find_module_by_prefix(ys, prefix)) == NULL)
                         ys1 = yang_find_module_by_prefix_yspec(ys_spec(ys), prefix);
                     if (ys1 != NULL)
@@ -350,10 +351,15 @@ xp_yang_eval(xp_yang_ctx  *xy,
         goto ok;
         break;
     case XP_ABSPATH:
-        /* Set context node to top node, and nodeset to that node only */
+        /* Set context node to lexical top module/submodule of the initial node */
         if (yang_keyword_get(xy->xy_node) != Y_SPEC){
-            if (ys_real_module(xy->xy_node, &xy->xy_node) < 0)
-                goto done;
+            yang_stmt *ytop = NULL;
+            if (xy->xy_initial)
+                ytop = ys_module(xy->xy_initial);
+            else
+                ytop = ys_module(xy->xy_node);
+            if (ytop)
+                xy->xy_node = ytop;
         }
         break;
     case XP_PRED:

--- a/lib/src/clixon_yang.c
+++ b/lib/src/clixon_yang.c
@@ -91,6 +91,27 @@
 #include "clixon_yang_schema_mount.h"
 #include "clixon_yang_internal.h" /* internal included by this file only, not API */
 
+/* Context for matching an import by module name and capturing its prefix */
+struct import_mod_ctx {
+    const char *modname;
+    const char *prefix;
+};
+
+/* Callback for yang_imports_foreach_scope: match import by module name and capture prefix */
+static int
+import_match_module_cb(yang_stmt *yimport, void *arg)
+{
+    struct import_mod_ctx *c = arg;
+    yang_stmt *yprefix;
+
+    if (strcmp(c->modname, yang_argument_get(yimport)) != 0)
+        return 0;
+    if ((yprefix = yang_find(yimport, Y_PREFIX, NULL)) == NULL)
+        return 0;
+    c->prefix = yang_argument_get(yprefix);
+    return 1; /* stop */
+}
+
 #ifdef XML_EXPLICIT_INDEX
 static int yang_search_index_extension(clixon_handle h, yang_stmt *yext, yang_stmt *ys);
 #endif
@@ -1847,25 +1868,30 @@ yang_find_prefix_by_namespace(yang_stmt  *ys,
     yang_stmt *yimport;
     yang_stmt *yprefix;
     int        inext;
+    yang_stmt *yscope; /* lexical origin */
+    yang_stmt *yinst;  /* instantiated node */
+    struct import_mod_ctx ctx;
 
     clixon_debug(CLIXON_DBG_YANG | CLIXON_DBG_DETAIL, "namespace %s", ns);
     if (prefix == NULL){
         clixon_err(OE_YANG, EINVAL, "prefix is NULL");
         goto done;
     }
-    /* First check if namespace is my own module */
-    if ((myns = yang_find_mynamespace(ys)) == NULL)
+    yscope = yang_orig_get(ys) ? yang_orig_get(ys) : ys;
+    yinst = ys;
+    /* First check if namespace is my own module (instantiated) */
+    if ((myns = yang_find_mynamespace(yinst)) == NULL)
         goto done;
     if (strcmp(myns, ns) == 0){
-        *prefix = yang_find_myprefix(ys); /* or NULL? */
+        *prefix = yang_find_myprefix(yinst); /* or NULL? */
         goto found;
     }
     /* Next, find namespaces in imported modules */
-    yspec = ys_spec(ys);
+    yspec = ys_spec(yscope);
     if ((ymod = yang_find_module_by_namespace(yspec, ns)) == NULL)
         goto notfound;
     modname = yang_argument_get(ymod);
-    my_ymod = ys_module(ys);
+    my_ymod = ys_module(yinst);
     /* Loop through import statements to find a match with ymod */
     inext = 0;
     while ((yimport = yn_iter(my_ymod, &inext)) != NULL) {
@@ -1875,6 +1901,17 @@ yang_find_prefix_by_namespace(yang_stmt  *ys,
             *prefix = yang_argument_get(yprefix);
             goto found;
         }
+    }
+    /* If not found, also check lexical module/import scope upwards */
+    ctx.modname = modname;
+    ctx.prefix = NULL;
+    if (yang_imports_foreach_scope(yscope, yspec,
+                                   import_match_module_cb,
+                                   &ctx) < 0)
+        goto done;
+    if (ctx.prefix){
+        *prefix = (char*)ctx.prefix;
+        goto found;
     }
  notfound:
     retval = 0; /* not found */

--- a/test/test_grouping_import_prefix_scope.sh
+++ b/test/test_grouping_import_prefix_scope.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Grouping in a submodule imports a module under one prefix, then the grouping is
+# used from another module that imports the same module under a different prefix.
+# Verify leafref resolution honors the lexical (submodule) prefix.
+
+# Magic line must be first in script (see README.md)
+s="$_"
+. ./lib.sh || if [ "$s" = $0 ]; then exit 0; else return 0; fi
+
+APPNAME=example
+
+cfg=$dir/grouping_import_prefix_scope.xml
+fprov=$dir/prov-main.yang
+fprovsub=$dir/prov-sub.yang
+fcons=$dir/cons-main.yang
+ftarget=$dir/if-target.yang
+
+# Enable autocli for all loaded modules (cons-main, prov-main, if-target)
+AUTOCLI=$(autocli_config "*" kw-nokey false)
+
+cat <<EOF >$cfg
+<clixon-config xmlns="http://clicon.org/config">
+  <CLICON_CONFIGFILE>$cfg</CLICON_CONFIGFILE>
+  <CLICON_YANG_DIR>$dir</CLICON_YANG_DIR>
+  <CLICON_YANG_DIR>${YANG_INSTALLDIR}</CLICON_YANG_DIR>
+  <CLICON_YANG_MAIN_FILE>$fcons</CLICON_YANG_MAIN_FILE>
+  <CLICON_CLISPEC_DIR>/usr/local/lib/$APPNAME/clispec</CLICON_CLISPEC_DIR>
+  <CLICON_CLI_DIR>/usr/local/lib/$APPNAME/cli</CLICON_CLI_DIR>
+  <CLICON_CLI_MODE>$APPNAME</CLICON_CLI_MODE>
+  <CLICON_SOCK>/usr/local/var/run/$APPNAME.sock</CLICON_SOCK>
+  <CLICON_BACKEND_PIDFILE>/usr/local/var/run/$APPNAME.pidfile</CLICON_BACKEND_PIDFILE>
+  <CLICON_XMLDB_DIR>/usr/local/var/$APPNAME</CLICON_XMLDB_DIR>
+  $AUTOCLI
+</clixon-config>
+EOF
+
+cat <<'EOF' >$ftarget
+module if-target {
+  yang-version 1.1;
+  namespace "urn:ift";
+  prefix t;
+
+  container interfaces {
+    list interface {
+      key "name";
+      leaf name {
+        type string;
+      }
+    }
+  }
+}
+EOF
+
+cat <<'EOF' >$fprov
+module prov-main {
+  yang-version 1.1;
+  namespace "urn:prov";
+  prefix p;
+
+  include prov-sub;
+}
+EOF
+
+cat <<'EOF' >$fprovsub
+submodule prov-sub {
+  belongs-to prov-main { prefix p; }
+  yang-version 1.1;
+
+  import if-target { prefix foo; }
+
+  grouping g {
+    container iface-ref {
+      leaf iface {
+        type leafref {
+          path "/foo:interfaces/foo:interface/foo:name";
+        }
+      }
+    }
+  }
+}
+EOF
+
+cat <<'EOF' >$fcons
+module cons-main {
+  yang-version 1.1;
+  namespace "urn:cons";
+  prefix c;
+
+  import prov-main { prefix p; }
+  import if-target { prefix bar; }
+
+  container top {
+    uses p:g;
+  }
+}
+EOF
+
+new "test params: -f $cfg"
+
+if [ $BE -ne 0 ]; then
+  new "kill old backend"
+  sudo clixon_backend -zf $cfg
+  if [ $? -ne 0 ]; then
+    err
+  fi
+  new "start backend -s init -f $cfg"
+  start_backend -s init -f $cfg
+fi
+
+new "wait backend"
+wait_backend
+
+XML=$(
+  cat <<EOF
+<interfaces xmlns="urn:ift">
+  <interface>
+    <name>eth0</name>
+  </interface>
+</interfaces>
+<top xmlns="urn:cons">
+  <iface-ref>
+    <iface>eth0</iface>
+  </iface-ref>
+</top>
+EOF
+)
+
+new "edit-config with grouping leafref defined in submodule import"
+expecteof_netconf "$clixon_netconf -qf $cfg" 0 "$DEFAULTHELLO" "<rpc $DEFAULTNS><edit-config><target><candidate/></target><config>$XML</config></edit-config></rpc>" "" "<rpc-reply $DEFAULTNS><ok/></rpc-reply>"
+
+new "validate candidate with grouping used across modules with different import prefixes"
+expecteof_netconf "$clixon_netconf -qf $cfg" 0 "$DEFAULTHELLO" "<rpc $DEFAULTNS><validate><source><candidate/></source></validate></rpc>" "" "<rpc-reply $DEFAULTNS><ok/></rpc-reply>"
+
+new "discard-changes"
+expecteof_netconf "$clixon_netconf -qf $cfg" 0 "$DEFAULTHELLO" "<rpc $DEFAULTNS><discard-changes/></rpc>" "" "<rpc-reply $DEFAULTNS><ok/></rpc-reply>"
+
+new "cli add interface to serve as leafref target"
+expectpart "$($clixon_cli -1 -f $cfg set interfaces interface eth0)" 0 "^$"
+
+new "cli tab-complete leafref from grouping defined in submodule scope"
+expectpart "$(printf 'set top iface-ref iface \t\n' | $clixon_cli -f $cfg 2>&1)" 0 eth0 --not-- "Prefix foo does not have an associated namespace" "Database error"
+
+new "discard-changes"
+expecteof_netconf "$clixon_netconf -qf $cfg" 0 "$DEFAULTHELLO" "<rpc $DEFAULTNS><discard-changes/></rpc>" "" "<rpc-reply $DEFAULTNS><ok/></rpc-reply>"
+
+if [ $BE -ne 0 ]; then
+  new "Kill backend"
+  # Check if premature kill
+  pid=$(pgrep -u root -f clixon_backend)
+  if [ -z "$pid" ]; then
+    err "backend already dead"
+  fi
+  # kill backend
+  stop_backend -f $cfg
+fi
+
+rm -rf $dir
+
+new "endtest"
+endtest

--- a/test/test_submodule_import_leafref.sh
+++ b/test/test_submodule_import_leafref.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Leafref in a submodule-only import (with nested includes and conflicting sibling prefixes):
+# ensure CLI tab-completion picks up the imported namespace from the lexical origin.
+# Matches the issue #637 reproducer and guards against picking the wrong prefix when another
+# submodule imports a different module with the same prefix.
+
+# Magic line must be first in script (see README.md)
+s="$_"
+. ./lib.sh || if [ "$s" = $0 ]; then exit 0; else return 0; fi
+
+APPNAME=example
+
+cfg=$dir/submodule_import_leafref.xml
+fplatform=$dir/test-platform.yang
+fmain=$dir/test-main.yang
+fsub=$dir/test-sub.yang
+fsubsub=$dir/test-subsub.yang
+fsub2=$dir/test-sub2.yang
+fif=$dir/test-if.yang
+falt=$dir/test-alt.yang
+
+cat <<EOF >$cfg
+<clixon-config xmlns="http://clicon.org/config">
+  <CLICON_CONFIGFILE>$cfg</CLICON_CONFIGFILE>
+  <CLICON_YANG_DIR>$dir</CLICON_YANG_DIR>
+  <CLICON_YANG_DIR>${YANG_INSTALLDIR}</CLICON_YANG_DIR>
+  <CLICON_YANG_MAIN_FILE>$fplatform</CLICON_YANG_MAIN_FILE>
+  <CLICON_CLISPEC_DIR>/usr/local/lib/$APPNAME/clispec</CLICON_CLISPEC_DIR>
+  <CLICON_CLI_DIR>/usr/local/lib/$APPNAME/cli</CLICON_CLI_DIR>
+  <CLICON_CLI_MODE>$APPNAME</CLICON_CLI_MODE>
+  <CLICON_SOCK>/usr/local/var/run/$APPNAME.sock</CLICON_SOCK>
+  <CLICON_BACKEND_PIDFILE>/usr/local/var/run/$APPNAME.pidfile</CLICON_BACKEND_PIDFILE>
+  <CLICON_XMLDB_DIR>/usr/local/var/$APPNAME</CLICON_XMLDB_DIR>
+</clixon-config>
+EOF
+
+cat <<'EOF' >$fplatform
+module test-platform {
+  yang-version 1.1;
+  namespace "urn:test:platform";
+  prefix tp;
+
+  import test-main { prefix tm; }
+  import test-if   { prefix tif; }
+
+  /* Entry point that pulls in the test modules */
+}
+EOF
+
+cat <<'EOF' >$fmain
+module test-main {
+  yang-version 1.1;
+  namespace "urn:test:main";
+  prefix tm;
+
+  include test-sub;
+  include test-sub2;
+
+  container top {
+    uses sub-top;
+  }
+}
+EOF
+
+cat <<'EOF' >$fsub
+submodule test-sub {
+  belongs-to test-main { prefix tm; }
+  yang-version 1.1;
+
+  include test-subsub;
+  import test-if { prefix tif; }
+
+  grouping sub-top {
+    uses sub-sub-top;
+    /* Direct leafref anchored in this submodule to cover the original issue */
+    container iface-ref-direct {
+      leaf interface {
+        type leafref {
+          path "/tif:interfaces/tif:interface/tif:name";
+        }
+      }
+    }
+  }
+}
+EOF
+
+cat <<'EOF' >$fsubsub
+submodule test-subsub {
+  belongs-to test-main { prefix tm; }
+  yang-version 1.1;
+
+  import test-if { prefix tif; }
+
+  grouping sub-sub-top {
+    container iface-ref {
+      leaf interface {
+        type leafref {
+          path "/tif:interfaces/tif:interface/tif:name";
+        }
+      }
+    }
+  }
+}
+EOF
+
+cat <<'EOF' >$fsub2
+submodule test-sub2 {
+  belongs-to test-main { prefix tm; }
+  yang-version 1.1;
+
+  /* Deliberately reuse prefix "tif" for a different module to ensure scope is correct */
+  import test-alt { prefix tif; }
+
+  container shadow {
+    leaf dummy {
+      type string;
+    }
+  }
+}
+EOF
+
+cat <<'EOF' >$fif
+module test-if {
+  yang-version 1.1;
+  namespace "urn:test:if";
+  prefix tif;
+
+  container interfaces {
+    list interface {
+      key "name";
+      leaf name {
+        type string;
+      }
+    }
+  }
+}
+EOF
+
+cat <<'EOF' >$falt
+module test-alt {
+  yang-version 1.1;
+  namespace "urn:test:alt";
+  prefix tif;
+
+  container alt-root {
+    leaf name {
+      type string;
+    }
+  }
+}
+EOF
+
+new "test params: -f $cfg"
+
+if [ $BE -ne 0 ]; then
+  new "kill old backend"
+  sudo clixon_backend -zf $cfg
+  if [ $? -ne 0 ]; then
+    err
+  fi
+  new "start backend -s init -f $cfg"
+  start_backend -s init -f $cfg
+fi
+
+new "wait backend"
+wait_backend
+
+XML=$(
+  cat <<EOF
+<interfaces xmlns="urn:test:if">
+  <interface>
+    <name>foo</name>
+  </interface>
+</interfaces>
+<top xmlns="urn:test:main">
+  <iface-ref>
+    <interface>foo</interface>
+  </iface-ref>
+  <iface-ref-direct>
+    <interface>foo</interface>
+  </iface-ref-direct>
+</top>
+EOF
+)
+
+new "edit-config with leafref defined in submodule import"
+expecteof_netconf "$clixon_netconf -qf $cfg" 0 "$DEFAULTHELLO" "<rpc $DEFAULTNS><edit-config><target><candidate/></target><config>$XML</config></edit-config></rpc>" "" "<rpc-reply $DEFAULTNS><ok/></rpc-reply>"
+
+new "validate candidate containing imported-prefix leafref"
+expecteof_netconf "$clixon_netconf -qf $cfg" 0 "$DEFAULTHELLO" "<rpc $DEFAULTNS><validate><source><candidate/></source></validate></rpc>" "" "<rpc-reply $DEFAULTNS><ok/></rpc-reply>"
+
+new "discard-changes"
+expecteof_netconf "$clixon_netconf -qf $cfg" 0 "$DEFAULTHELLO" "<rpc $DEFAULTNS><discard-changes/></rpc>" "" "<rpc-reply $DEFAULTNS><ok/></rpc-reply>"
+
+new "cli add interface to serve as leafref target"
+expectpart "$($clixon_cli -1 -f $cfg set interfaces interface foo)" 0 "^$"
+
+new "cli tab-complete leafref using submodule import"
+expectpart "$(printf 'set top iface-ref interface \t\n' | $clixon_cli -f $cfg 2>&1)" 0 foo --not-- "Prefix tif does not have an associated namespace" "Database error"
+
+new "cli tab-complete leafref using directly-including submodule import"
+expectpart "$(printf 'set top iface-ref-direct interface \t\n' | $clixon_cli -f $cfg 2>&1)" 0 foo --not-- "Prefix tif does not have an associated namespace" "Database error"
+
+new "cli discard"
+expectpart "$($clixon_cli -1f $cfg discard)" 0 "^$"
+
+if [ $BE -ne 0 ]; then
+  new "Kill backend"
+  # Check if premature kill
+  pid=$(pgrep -u root -f clixon_backend)
+  if [ -z "$pid" ]; then
+    err "backend already dead"
+  fi
+  # kill backend
+  stop_backend -f $cfg
+fi
+
+rm -rf $dir
+
+new "endtest"
+endtest


### PR DESCRIPTION
- Add yang_imports_foreach_scope() and use it to resolve imports
  bottom-up from the lexical origin (ys_orig) through the
  belongs-to chain, skipping sibling submodules.
- Make nsctx building use the instantiated node’s own prefix/namespace,
  but gather import prefixes from the lexical scope;
  keep xml_nsctx_yangspec to module defaults only to avoid cross-module
  prefix collisions.
- Scope prefix/namespace lookups (yang_find_module_by_prefix,
  yang_find_prefix_by_namespace) to the lexical origin, with own-module
  matching via the instantiated node; accept submodules in XPath
  absolute evaluation.
- Leafref validation now resolves paths from the lexical origin, falls
  back to the instantiated tree if needed, and guards against missing
  cv templates to avoid crashes.

Fixes grouping/augment leafref resolution and prevents wrong-prefix
matches when submodules reuse prefixes differently.
https://github.com/clicon/clixon/issues/637