### PR TITLE
Preserve OpenConfig layout in test images

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -144,7 +144,7 @@ RUN adduser -D -H clicon
 
 COPY --from=0 /clixon/build/ /
 COPY --from=0 /usr/local/share/yang/ /usr/local/share/yang/
-COPY --from=0 /usr/local/share/openconfig/* /usr/local/share/openconfig/
+COPY --from=0 /usr/local/share/openconfig/ /usr/local/share/openconfig/
 COPY --from=0 /usr/local/share/mib-yangs/* /usr/local/share/mib-yangs/
 COPY --from=0 /clixon/build/mibs/* /usr/share/snmp/mibs/
 

--- a/docker/test/Dockerfile.fcgi
+++ b/docker/test/Dockerfile.fcgi
@@ -163,7 +163,7 @@ RUN adduser www-data clicon
 
 COPY --from=0 /clixon/build/ /
 COPY --from=0 /usr/local/share/yang/ /usr/local/share/yang/
-COPY --from=0 /usr/local/share/openconfig/* /usr/local/share/openconfig/
+COPY --from=0 /usr/local/share/openconfig/ /usr/local/share/openconfig/
 COPY --from=0 /usr/local/share/mib-yangs/* /usr/local/share/mib-yangs/
 COPY --from=0 /clixon/build/mibs/* /usr/share/snmp/mibs/
 

--- a/docker/test/Dockerfile.native
+++ b/docker/test/Dockerfile.native
@@ -162,7 +162,7 @@ RUN adduser -D -H clicon
 
 COPY --from=0 /clixon/build/ /
 COPY --from=0 /usr/local/share/yang/ /usr/local/share/yang/
-COPY --from=0 /usr/local/share/openconfig/* /usr/local/share/openconfig/
+COPY --from=0 /usr/local/share/openconfig/ /usr/local/share/openconfig/
 COPY --from=0 /usr/local/share/mib-yangs/* /usr/local/share/mib-yangs/
 COPY --from=0 /clixon/build/mibs/* /usr/share/snmp/mibs/
 


### PR DESCRIPTION
The stage‑2 COPY --from=0 /usr/local/share/openconfig/* flattened the public directory into /usr/local/share/openconfig, so the expected /usr/local/share/openconfig/public path was missing at runtime. This change copies the whole directory tree so
OPENCONFIG=/usr/local/share/openconfig/public works again in the test container.