### PR TITLE
restconf: Fix fields filter dropping nodes defined in YANG submodules

### DIFF
--- a/apps/restconf/restconf_methods_get.c
+++ b/apps/restconf/restconf_methods_get.c
@@ -122,8 +122,10 @@ restconf_fields_filter(cxobj *xdata,
         if (xml_type(x) != CX_ELMNT)
             continue;
         ynode = xml_spec(x);
-        ymod = (ynode != NULL) ? ys_module(ynode) : NULL;
-        modname = (ymod != NULL) ? yang_argument_get(ymod) : NULL;
+        ymod = NULL;
+        if (ynode != NULL && ys_real_module(ynode, &ymod) < 0)
+            goto done;
+        modname = (ymod != NULL) ? yang_argument_get(ymod) : xml_prefix(x);
         nodename = xml_name(x);
         found = 0;
         for (j = 0; j < nf; j++){


### PR DESCRIPTION
When a top-level data node's YANG spec belongs to a submodule (e.g. the 'snmp' container spec is in 'ietf-snmp-engine' which belongs-to 'ietf-snmp'), ys_module() returns the submodule name ('ietf-snmp-engine') rather than the real module name ('ietf-snmp'). The filter then fails to match 'fields=ietf-snmp:snmp' and removes the node from the response.

Fix: replace ys_module() with ys_real_module(), which follows the belongs-to chain to find the actual top-level module name -- the same function used by the JSON serializer (xml2json1_cbuf) to output 'module:node' keys. This makes the filter consistent with JSON output.

Additionally, fall back to xml_prefix(x) when xml_spec() returns NULL (no YANG schema annotation), instead of silently dropping the node.

Reproducer:
  GET /restconf/data?fields=ietf-snmp:snmp
  Before fix: returns empty {}
  After fix:  returns ietf-snmp:snmp subtree correctly