### PR TITLE
Increased the size of the error message line

### DIFF
--- a/lib/clixon/clixon_err.h
+++ b/lib/clixon/clixon_err.h
@@ -48,7 +48,7 @@
 /*
  * Constants
  */
-#define ERR_STRLEN 256
+#define ERR_STRLEN 2048
 
 /* Special error number for clicon_suberrno
  * For catching xml parse errors as exceptions


### PR DESCRIPTION
@olofhagsand I came across a situation where the 256 size is not always enough to output a message