### PR TITLE
Sort RESTCONF payload tree before optimized XPath evaluation. Fixed issue 679

### DIFF
--- a/apps/restconf/restconf_methods.c
+++ b/apps/restconf/restconf_methods.c
@@ -300,6 +300,8 @@ api_data_write(clixon_handle h,
     if ((xdata00 = xml_dup(xtop)) == NULL)
         goto done;
     if (xpath){
+        if (xml_sort_recurse(xdata00) < 0)
+            goto done;
         if ((xdata0 = xpath_first(xdata00, nsc, "%s/..", xpath)) == NULL){
             clixon_err(OE_XML, 0, "XML not found using xpath %s", xpath);
             goto done;


### PR DESCRIPTION
Optimized XPath lookup may operate on a freshly parsed PATCH payload before its children are sorted according to YANG ordering.

Sort the temporary payload tree before evaluating XPath expressions to ensure optimized list lookups work correctly.