### PR TITLE
cli: persist history after every command, not only at exit

### DIFF
--- a/apps/cli/cli_main.c
+++ b/apps/cli/cli_main.c
@@ -268,6 +268,10 @@ cli_interactive(clixon_handle h)
             cligen_exiting_set(cli_cligen(h), 1);
             continue;
         }
+        /* Persist history now instead of only at exit, so a crash or kill
+         * does not lose commands entered in this session. */
+        if (cli_history_save(h) < 0)
+            goto done;
         /* Here errors are handled */
         if (clicon_parse(h, cmd, &new_mode, &result, NULL) < 0)
             goto done;


### PR DESCRIPTION
@olofhagsand Hi
Previously cli_history_save() was called once, from cli_terminate(), so the CLI history file was only ever written when the process exited cleanly. If the CLI session was killed, crashed, or lost connection, none of the commands entered in that session were saved.

Flush history right after each command is read in cli_interactive(), using the same cli_history_save()/cligen_hist_file_save() already used at exit. This is cheap since the history ring buffer is small (CLIGEN_HISTSIZE_DEFAULT / CLICON_CLI_HIST_SIZE, 100 lines by default).


Claude-Session: https://claude.ai/code/session_01J8EhHbmxAdJbYePkPu3cnE